### PR TITLE
38 update matchdto serializer with new fields from riot

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
@@ -1,5 +1,6 @@
 package com.lowbudgetlcs.models.match
 
+import com.lowbudgetlcs.models.match.runes.MatchParticipantPerks
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
@@ -21,7 +21,6 @@ data class MatchParticipant(
     @SerialName("assists") val assists: Int,
     @SerialName("champLevel") val championLevel: Int,
     @SerialName("goldEarned") val goldEarned: Int,
-    @SerialName("visionScore") val visionScore: Long,
     @SerialName("totalDamageDealtToChampions") val totalDamageToChampions: Long,
     @SerialName("totalHealsOnTeammates") val totalHealsOnTeammates: Long,
     @SerialName("totalDamageShieldedOnTeammates") val totalDamageShieldedOnTeammates: Long,
@@ -57,5 +56,23 @@ data class MatchParticipant(
     @SerialName("summoner2Id") val summoner2Id: Int,
 
     // **Win Status**
-    @SerialName("win") val win: Boolean
+    @SerialName("win") val win: Boolean,
+
+    // **Player Interactions - Pings**
+    @SerialName("allInPings") val allInPings: Short,
+    @SerialName("assistMePings") val assistMePings: Short,
+    @SerialName("commandPings") val commandPings: Short,
+    @SerialName("enemyMissingPings") val enemyMissingPings: Short,
+    @SerialName("enemyVisionPings") val enemyVisionPings: Short,
+    @SerialName("holdPings") val holdPings: Short,
+    @SerialName("getBackPings") val getBackPings: Short,
+    @SerialName("onMyWayPings") val onMyWayPings: Short,
+    @SerialName("needVisionPings") val needVisionPings: Short,
+    @SerialName("pushPings") val pushPings: Short,
+
+    // **Vision Stats**
+    @SerialName("visionScore") val visionScore: Short,
+    @SerialName("pinkWardsPlaced") val pinkWardsPlaced: Short,
+    @SerialName("wardsKilled") val wardsKilled: Short,
+    @SerialName("wardsPlaced") val wardsPlaced: Short
 )

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/MatchParticipant.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 data class MatchParticipant(
     @SerialName("participantId") val id: Int,
     @SerialName("puuid") val playerUniqueUserId: String,
+    @SerialName("profileIcon") val profileIcon: Long,
     @SerialName("riotIdGameName") val riotGameName: String?,
     @SerialName("riotIdTagline") val riotTagline: String?,
     @SerialName("teamId") val teamId: Int,
@@ -22,6 +23,7 @@ data class MatchParticipant(
     @SerialName("assists") val assists: Int,
     @SerialName("champLevel") val championLevel: Int,
     @SerialName("goldEarned") val goldEarned: Int,
+    @SerialName("goldSpent") val goldSpent: Int,
     @SerialName("totalDamageDealtToChampions") val totalDamageToChampions: Long,
     @SerialName("totalHealsOnTeammates") val totalHealsOnTeammates: Long,
     @SerialName("totalDamageShieldedOnTeammates") val totalDamageShieldedOnTeammates: Long,
@@ -29,12 +31,19 @@ data class MatchParticipant(
     @SerialName("damageSelfMitigated") val damageSelfMitigated: Long,
     @SerialName("damageDealtToTurrets") val damageDealtToTurrets: Long,
     @SerialName("longestTimeSpentLiving") val longestTimeSpentLiving: Long,
+    @SerialName("largestCriticalStrike") val largestCriticalStrike: Int,
 
     // **Multi-kill Statistics**
+    @SerialName("largestMultiKill") val largestMultiKill: Short,
+    @SerialName("largestKillingSpree") val largestKillingSpree: Short,
     @SerialName("doubleKills") val doubleKills: Short,
     @SerialName("tripleKills") val tripleKills: Short,
     @SerialName("quadraKills") val quadraKills: Short,
     @SerialName("pentaKills") val pentaKills: Short,
+
+    // **First Blood**
+    @SerialName("firstBloodAssist") val firstBloodAssist: Boolean,
+    @SerialName("firstBloodKill") val firstBloodKill: Boolean,
 
     // **Creep Score**
     @SerialName("totalMinionsKilled") val totalMinionsKilled: Int,
@@ -71,8 +80,21 @@ data class MatchParticipant(
     @SerialName("needVisionPings") val needVisionPings: Short,
     @SerialName("pushPings") val pushPings: Short,
 
+    // **Objective Stats**
+    @SerialName("baronKills") val baronKills: Short,
+    @SerialName("dragonKills") val dragonKills: Short,
+    @SerialName("firstTowerKill") val firstTowerKill: Boolean,
+    @SerialName("firstTowerAssist") val firstTowerAssist: Boolean,
+    @SerialName("turretKills") val turretKills: Short,
+    @SerialName("turretTakedowns") val turretTakedowns: Short,
+    @SerialName("inhibitorKills") val inhibitorKills: Short,
+    @SerialName("inhibitorTakedowns") val inhibitorTakedowns: Short,
+    @SerialName("inhibitorsLost") val inhibitorsLost: Short,
+    @SerialName("objectivesStolen") val objectivesStolen: Short,
+
+
     // **Vision Stats**
-    @SerialName("visionScore") val visionScore: Short,
+    @SerialName("visionScore") val visionScore: Long,
     @SerialName("pinkWardsPlaced") val pinkWardsPlaced: Short,
     @SerialName("wardsKilled") val wardsKilled: Short,
     @SerialName("wardsPlaced") val wardsPlaced: Short

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/MatchPerkStyle.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/MatchPerkStyle.kt
@@ -1,9 +1,0 @@
-package com.lowbudgetlcs.models.match
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class MatchPerkStyle(
-    @SerialName("style") val style: Int
-)

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/runes/MatchParticipantPerks.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/runes/MatchParticipantPerks.kt
@@ -1,9 +1,10 @@
-package com.lowbudgetlcs.models.match
+package com.lowbudgetlcs.models.match.runes
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class MatchParticipantPerks(
+    @SerialName("statPerks") val statPerks: PerkStats,
     @SerialName("styles") val perkStyles: List<MatchPerkStyle>
 )

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/runes/MatchPerkStyle.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/runes/MatchPerkStyle.kt
@@ -1,0 +1,11 @@
+package com.lowbudgetlcs.models.match.runes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MatchPerkStyle(
+    @SerialName("description") val description: String,
+    @SerialName("selections") val selections: List<PerkStyleSelection>,
+    @SerialName("style") val style: Int
+)

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/runes/PerkStats.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/runes/PerkStats.kt
@@ -1,0 +1,11 @@
+package com.lowbudgetlcs.models.match.runes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PerkStats(
+    @SerialName("defense") val defense: Int,
+    @SerialName("flex") val flex: Int,
+    @SerialName("offense") val offense: Int
+)

--- a/src/main/kotlin/com/lowbudgetlcs/models/match/runes/PerkStyleSelection.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/models/match/runes/PerkStyleSelection.kt
@@ -1,0 +1,12 @@
+package com.lowbudgetlcs.models.match.runes
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PerkStyleSelection(
+    @SerialName("perk") val perkId: Int,
+    @SerialName("var1") val var1: Int,
+    @SerialName("var2") val var2: Int,
+    @SerialName("var3") val var3: Int
+)


### PR DESCRIPTION
Closes #38.

I'M SO BACK.
The following fields are now accounted for by Denny's (requires further testing) (pls test before merging this time)

### Fields Covered
I am missing:

- short_code
- team_kills

not sure what those are but lmk
![image](https://github.com/user-attachments/assets/786060bf-efde-41b5-b2bd-f433ca954013)
