### PR TITLE
feat: Add series completion state (V011)

### DIFF
--- a/src/itest/kotlin/SeriesRepositoryTest.kt
+++ b/src/itest/kotlin/SeriesRepositoryTest.kt
@@ -17,10 +17,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.testcontainers.JdbcDatabaseContainerSpecExtension
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
+import org.jooq.storage.tables.references.SERIES_RESULTS
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.MountableFile
 import java.time.Instant
@@ -91,5 +93,84 @@ class SeriesRepositoryTest :
             val series = repo.getAllByEventId(event.id)
             series.shouldNotBeEmpty()
             series.shouldHaveSize(5)
+        }
+
+        test("a newly inserted series is not completed") {
+            val created = repo.insert(newSeries)
+            created.shouldNotBeNull()
+
+            created.completed shouldBe false
+            created.completedAt.shouldBeNull()
+            created.reopenedAt.shouldBeNull()
+        }
+
+        test("complete sets the flag and stamps completedAt") {
+            val created = repo.insert(newSeries)
+            created.shouldNotBeNull()
+            val at = Instant.parse("2026-07-14T23:12:04Z")
+
+            val completed = repo.complete(created.id, at)
+            completed.shouldNotBeNull()
+
+            completed.completed shouldBe true
+            completed.completedAt shouldBe at
+            completed.reopenedAt.shouldBeNull()
+            repo.getById(created.id)?.completed shouldBe true
+        }
+
+        test("reopen clears completion, stamps reopenedAt and preserves series_results") {
+            val created = repo.insert(newSeries)
+            created.shouldNotBeNull()
+            dsl
+                .insertInto(SERIES_RESULTS)
+                .set(SERIES_RESULTS.SERIES_ID, created.id.value)
+                .set(SERIES_RESULTS.WINNER_TEAM_ID, team1.id.value)
+                .set(SERIES_RESULTS.LOSER_TEAM_ID, team2.id.value)
+                .execute()
+            repo.complete(created.id, Instant.parse("2026-07-14T23:12:04Z"))
+            val at = Instant.parse("2026-07-15T09:00:00Z")
+
+            val reopened = repo.reopen(created.id, at)
+            reopened.shouldNotBeNull()
+
+            reopened.completed shouldBe false
+            reopened.completedAt.shouldBeNull()
+            reopened.reopenedAt shouldBe at
+            reopened.result.shouldNotBeNull()
+            reopened.result?.winningTeamId shouldBe team1.id
+        }
+
+        test("the V011 backfill completes series in ended events and leaves active ones alone") {
+            val e = EventRepository(dsl)
+            val endedEvent =
+                e.insert(
+                    NewEvent(
+                        name = "Ended".toEventName(),
+                        description = "An event that has already finished.".toEventDescription(),
+                        startDate = Instant.now().minusSeconds(7_200L),
+                        endDate = Instant.now().minusSeconds(3_600L),
+                        status = EventStatus.COMPLETED,
+                        eventStages = setOf(EventStage.REGULAR_SEASON),
+                    ),
+                    riotTournamentId = 2.toRiotTournamentId(),
+                ) ?: throw Exception("Failed to insert ended event.")
+            val stale =
+                repo.insert(newSeries.copy(eventId = endedEvent.id))
+                    ?: throw Exception("Failed to insert series in ended event.")
+            val active =
+                repo.insert(newSeries)
+                    ?: throw Exception("Failed to insert series in active event.")
+
+            dsl.execute(
+                """
+                UPDATE dennys.series s SET completed = true, completed_at = e.end_date
+                  FROM dennys.events e WHERE e.id = s.event_id AND e.end_date < now()
+                """.trimIndent(),
+            )
+
+            repo.getById(stale.id)?.completed shouldBe true
+            repo.getById(stale.id)?.completedAt shouldBe endedEvent.endDate
+            repo.getById(active.id)?.completed shouldBe false
+            repo.getById(active.id)?.completedAt.shouldBeNull()
         }
     })

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Series.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Series.kt
@@ -4,6 +4,7 @@ import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.types.TeamId
+import java.time.Instant
 
 data class Series(
     val id: SeriesId,
@@ -12,4 +13,7 @@ data class Series(
     val totalGames: Int,
     val participants: Pair<TeamId, TeamId>,
     val result: SeriesResult?,
+    val completed: Boolean,
+    val completedAt: Instant?,
+    val reopenedAt: Instant?,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/series/ISeriesRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/series/ISeriesRepository.kt
@@ -4,6 +4,7 @@ import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import java.time.Instant
 
 interface ISeriesRepository {
     fun insert(newSeries: NewSeries): Series?
@@ -13,4 +14,14 @@ interface ISeriesRepository {
     fun getAllByEventId(id: EventId): List<Series>
 
     fun delete(id: SeriesId)
+
+    fun complete(
+        id: SeriesId,
+        completedAt: Instant,
+    ): Series?
+
+    fun reopen(
+        id: SeriesId,
+        reopenedAt: Instant,
+    ): Series?
 }

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
@@ -17,6 +17,7 @@ import org.jooq.impl.DSL.select
 import org.jooq.storage.tables.references.SERIES
 import org.jooq.storage.tables.references.SERIES_RESULTS
 import org.jooq.storage.tables.references.TEAM_TO_SERIES
+import java.time.Instant
 
 class SeriesRepository(
     private val dsl: DSLContext,
@@ -61,6 +62,33 @@ class SeriesRepository(
         dsl.delete(SERIES).where(SERIES.ID.eq(id.value)).execute()
     }
 
+    override fun complete(
+        id: SeriesId,
+        completedAt: Instant,
+    ): Series? {
+        dsl
+            .update(SERIES)
+            .set(SERIES.COMPLETED, true)
+            .set(SERIES.COMPLETED_AT, completedAt)
+            .where(SERIES.ID.eq(id.value))
+            .execute()
+        return getById(id)
+    }
+
+    override fun reopen(
+        id: SeriesId,
+        reopenedAt: Instant,
+    ): Series? {
+        dsl
+            .update(SERIES)
+            .set(SERIES.COMPLETED, false)
+            .setNull(SERIES.COMPLETED_AT)
+            .set(SERIES.REOPENED_AT, reopenedAt)
+            .where(SERIES.ID.eq(id.value))
+            .execute()
+        return getById(id)
+    }
+
     // Typed multiset to select all teams associated with a series.
     val participants by lazy {
         multiset(
@@ -75,6 +103,9 @@ class SeriesRepository(
                 SERIES.TOTAL_GAMES,
                 SERIES.EVENT_ID,
                 SERIES.STAGE,
+                SERIES.COMPLETED,
+                SERIES.COMPLETED_AT,
+                SERIES.REOPENED_AT,
                 participants,
                 SERIES_RESULTS.WINNER_TEAM_ID,
                 SERIES_RESULTS.LOSER_TEAM_ID,
@@ -88,6 +119,7 @@ class SeriesRepository(
         val eventId = row[SERIES.EVENT_ID]?.toEventId() ?: return null
         val eventStage = row[SERIES.STAGE]?.let { EventStage.valueOf(it) } ?: return null
         val totalGames = row[SERIES.TOTAL_GAMES] ?: return null
+        val completed = row[SERIES.COMPLETED] ?: return null
         val p = row[participants].mapNotNull { it.value1()?.toTeamId() }
         val participants = Pair(p[0], p[1])
         // potentially null data
@@ -102,6 +134,9 @@ class SeriesRepository(
                 totalGames = totalGames,
                 participants = participants,
                 result = if (winner != null && loser != null) SeriesResult(winner, loser) else null,
+                completed = completed,
+                completedAt = row[SERIES.COMPLETED_AT],
+                reopenedAt = row[SERIES.REOPENED_AT],
             )
         return s
     }

--- a/src/main/kotlin/org/jooq/storage/tables/Series.kt
+++ b/src/main/kotlin/org/jooq/storage/tables/Series.kt
@@ -4,6 +4,8 @@
 package org.jooq.storage.tables
 
 
+import java.time.Instant
+
 import kotlin.collections.Collection
 import kotlin.collections.List
 
@@ -99,6 +101,21 @@ open class Series(
      * The column <code>dennys.series.stage</code>.
      */
     val STAGE: TableField<SeriesRecord, String?> = createField(DSL.name("stage"), SQLDataType.CLOB.nullable(false).defaultValue(DSL.field(DSL.raw("'REGULAR_SEASON'::text"), SQLDataType.CLOB)), this, "")
+
+    /**
+     * The column <code>dennys.series.completed</code>.
+     */
+    val COMPLETED: TableField<SeriesRecord, Boolean?> = createField(DSL.name("completed"), SQLDataType.BOOLEAN.nullable(false).defaultValue(DSL.field(DSL.raw("false"), SQLDataType.BOOLEAN)), this, "")
+
+    /**
+     * The column <code>dennys.series.completed_at</code>.
+     */
+    val COMPLETED_AT: TableField<SeriesRecord, Instant?> = createField(DSL.name("completed_at"), SQLDataType.INSTANT, this, "")
+
+    /**
+     * The column <code>dennys.series.reopened_at</code>.
+     */
+    val REOPENED_AT: TableField<SeriesRecord, Instant?> = createField(DSL.name("reopened_at"), SQLDataType.INSTANT, this, "")
 
     private constructor(alias: Name, aliased: Table<SeriesRecord>?): this(alias, null, null, null, aliased, null, null)
     private constructor(alias: Name, aliased: Table<SeriesRecord>?, parameters: Array<Field<*>?>?): this(alias, null, null, null, aliased, parameters, null)

--- a/src/main/kotlin/org/jooq/storage/tables/records/SeriesRecord.kt
+++ b/src/main/kotlin/org/jooq/storage/tables/records/SeriesRecord.kt
@@ -4,6 +4,8 @@
 package org.jooq.storage.tables.records
 
 
+import java.time.Instant
+
 import org.jooq.Record1
 import org.jooq.impl.UpdatableRecordImpl
 import org.jooq.storage.tables.Series
@@ -31,6 +33,18 @@ open class SeriesRecord() : UpdatableRecordImpl<SeriesRecord>(Series.SERIES) {
         set(value): Unit = set(3, value)
         get(): String? = get(3) as String?
 
+    open var completed: Boolean?
+        set(value): Unit = set(4, value)
+        get(): Boolean? = get(4) as Boolean?
+
+    open var completedAt: Instant?
+        set(value): Unit = set(5, value)
+        get(): Instant? = get(5) as Instant?
+
+    open var reopenedAt: Instant?
+        set(value): Unit = set(6, value)
+        get(): Instant? = get(6) as Instant?
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -40,11 +54,14 @@ open class SeriesRecord() : UpdatableRecordImpl<SeriesRecord>(Series.SERIES) {
     /**
      * Create a detached, initialised SeriesRecord
      */
-    constructor(id: Int? = null, eventId: Int? = null, totalGames: Int? = null, stage: String? = null): this() {
+    constructor(id: Int? = null, eventId: Int? = null, totalGames: Int? = null, stage: String? = null, completed: Boolean? = null, completedAt: Instant? = null, reopenedAt: Instant? = null): this() {
         this.id = id
         this.eventId = eventId
         this.totalGames = totalGames
         this.stage = stage
+        this.completed = completed
+        this.completedAt = completedAt
+        this.reopenedAt = reopenedAt
         resetChangedOnNotNull()
     }
 }

--- a/src/migrations/sql/V011__add_series_completion.sql
+++ b/src/migrations/sql/V011__add_series_completion.sql
@@ -1,0 +1,12 @@
+START TRANSACTION;
+SET search_path = dennys;
+
+ALTER TABLE series
+  ADD COLUMN completed    BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN completed_at TIMESTAMPTZ,
+  ADD COLUMN reopened_at  TIMESTAMPTZ;
+
+UPDATE series s SET completed = true, completed_at = e.end_date
+  FROM events e WHERE e.id = s.event_id AND e.end_date < now();
+
+COMMIT;

--- a/src/test/kotlin/services/SeriesServiceTest.kt
+++ b/src/test/kotlin/services/SeriesServiceTest.kt
@@ -82,6 +82,9 @@ class SeriesServiceTest :
                 participants = participatingTeams,
                 result = null,
                 eventStage = EventStage.REGULAR_SEASON,
+                completed = false,
+                completedAt = null,
+                reopenedAt = null,
             )
 
         val newSeries =
@@ -121,6 +124,9 @@ class SeriesServiceTest :
                         participants = participatingTeams,
                         result = null,
                         eventStage = EventStage.REGULAR_SEASON,
+                        completed = false,
+                        completedAt = null,
+                        reopenedAt = null,
                     ),
                     Series(
                         id = SeriesId(2),
@@ -129,6 +135,9 @@ class SeriesServiceTest :
                         participants = participatingTeams,
                         result = null,
                         eventStage = EventStage.REGULAR_SEASON,
+                        completed = false,
+                        completedAt = null,
+                        reopenedAt = null,
                     ),
                 )
 


### PR DESCRIPTION
Closes #192. Part of #189.

Series completion is the **routing flag** the rest of the feature turns on: with two series for the same team pair in the same stage, it is the only thing that tells a fresh lookup which one a new tournament code belongs to.

## Migration

`V011__add_series_completion.sql`, authored **unlocked** — it gets renamed to `*_LOCKED.sql` when 1.4.0 reaches `main`, as `c77de89` did for V010. Follows V010's `START TRANSACTION; SET search_path = dennys; … COMMIT;` shape. No Flyway involved; these run via `docker-entrypoint-initdb.d` locally and in testcontainers, and are scp'd to the server for `release.sh`.

```sql
ALTER TABLE series
  ADD COLUMN completed    BOOLEAN NOT NULL DEFAULT false,
  ADD COLUMN completed_at TIMESTAMPTZ,
  ADD COLUMN reopened_at  TIMESTAMPTZ;

UPDATE series s SET completed = true, completed_at = e.end_date
  FROM events e WHERE e.id = s.event_id AND e.end_date < now();
```

The backfill stops every historical repeat pair reading as active once completion starts routing new codes. `reopened_at` exists so automatic completion does not immediately slam shut a series a human deliberately reopened — without it, reopening a series that already meets the win threshold would re-close on the very next result write.

`make jooq` was re-run and the generated code is committed. `COMPLETED_AT` and `REOPENED_AT` map to `Instant` through the existing `TIMESTAMPTZ → INSTANT` forced type in `JooqGenerator.kt:43-46`, and `COMPLETED` picked up `nullable(false)` with its default.

## Domain and repository

- `Series` gains `completed: Boolean`, `completedAt: Instant?`, `reopenedAt: Instant?`. `completed` is non-null — a series is either open or closed, never unknown.
- `selectSeries()` and `rowToSeries` read the three new columns.
- `ISeriesRepository` gains `complete` and `reopen`. It previously had **no update method at all** — only `insert`, `getById`, `getAllByEventId`, `delete` — which is why nothing in the codebase could write `series_results` or flip any flag.

Both new methods take the timestamp as a parameter rather than calling `Instant.now()` internally. That matches how the codebase already works — `AuthService` owns the clock and repositories take values — and it keeps the tests deterministic.

`reopen` clears `completed` and `completed_at` and stamps `reopened_at`. It only touches `series` columns, so any `series_results` row is preserved by construction; there is a test asserting it.

## Verification

Integration coverage added to `src/itest/kotlin/SeriesRepositoryTest.kt`. Each test was confirmed to have actually executed, rather than inferred from a green build:

```
[pass] a newly inserted series is not completed
[pass] complete sets the flag and stamps completedAt
[pass] reopen clears completion, stamps reopenedAt and preserves series_results
[pass] the V011 backfill completes series in ended events and leaves active ones alone
```

- [x] A newly inserted series reads `completed = false`, both timestamps null
- [x] `complete` sets the flag and stamps `completed_at`
- [x] `reopen` clears the flag, stamps `reopened_at`, and preserves any `series_results` row
- [x] The backfill marks series in already-ended events complete, and leaves series in active events alone
- [x] `make jooq` regenerates cleanly and `make test` is green

`./gradlew clean assemble test itest` passes locally, and CI is green on all three jobs.

### Caveat on the backfill test

The migration runs at container init against an **empty** database, so there is no data for it to touch and the applied migration cannot be observed directly. That test inserts a series in an ended event and one in an active event, then re-executes the same `UPDATE` statement and asserts the outcome.

It genuinely validates the SQL — the join and the `end_date < now()` predicate — but it is testing the statement, not the migration's application. Doing better would need a second container seeded before init. Flagging it so the coverage is not read as stronger than it is.

### Lint

`make check` fails, but it **already failed on `release/1.4.0`** before this change — 190 pre-existing ktlint violations in `main` plus more in `test`, none in any file touched here (verified by grep against the ktlint reports). `detekt` passes. Lint is not part of CI either; `run-tests-on-push.yml` runs `assemble`, `test` and `itest` only.

## Not included

No service-layer wiring and no endpoints — `complete`/`reopen` are repository methods with no caller yet. The automatic completion evaluation is #196, and the endpoints that expose this are #199.

`reopenedAt` is deliberately absent from the API DTOs, per #189. Whether it should be exposed on `SeriesWithGamesDto` is noted for discussion on #199.
