### PR TITLE
fix: Deterministic series ordering and completion filtering

### DIFF
--- a/src/itest/kotlin/SeriesRepositoryTest.kt
+++ b/src/itest/kotlin/SeriesRepositoryTest.kt
@@ -6,6 +6,8 @@ import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
 import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.event.models.types.EventStatus
 import com.lowbudgetlcs.domain.series.models.NewSeries
+import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.filterByCompletion
 import com.lowbudgetlcs.domain.team.models.NewTeam
 import com.lowbudgetlcs.domain.team.models.Team
 import com.lowbudgetlcs.domain.team.models.toTeamName
@@ -138,6 +140,69 @@ class SeriesRepositoryTest :
             reopened.reopenedAt shouldBe at
             reopened.result.shouldNotBeNull()
             reopened.result?.winningTeamId shouldBe team1.id
+        }
+
+        test("two series with the same pair and stage keep a stable id order across calls") {
+            val e = EventRepository(dsl)
+            val orderingEvent =
+                e.insert(
+                    NewEvent(
+                        name = "Ordering".toEventName(),
+                        description = "Two series, same pair, same stage.".toEventDescription(),
+                        startDate = Instant.now(),
+                        endDate = Instant.now().plusSeconds(3_600L),
+                        status = EventStatus.ACTIVE,
+                        eventStages = setOf(EventStage.PLAYOFFS),
+                    ),
+                    riotTournamentId = 3.toRiotTournamentId(),
+                ) ?: throw Exception("Failed to insert ordering event.")
+            val repeatPair = newSeries.copy(eventId = orderingEvent.id, eventStage = EventStage.PLAYOFFS)
+            val first = repo.insert(repeatPair) ?: throw Exception("Failed to insert first series.")
+            val second = repo.insert(repeatPair) ?: throw Exception("Failed to insert second series.")
+            val expected = listOf(first.id, second.id).sortedBy { it.value }
+
+            repo.getAllByEventId(orderingEvent.id).map { it.id } shouldBe expected
+
+            repo.complete(first.id, Instant.parse("2026-07-14T23:12:04Z"))
+
+            repo.getAllByEventId(orderingEvent.id).map { it.id } shouldBe expected
+            repo.getAllByEventId(orderingEvent.id).map { it.id } shouldBe expected
+        }
+
+        test("completion filtering splits two series that are otherwise identical") {
+            val e = EventRepository(dsl)
+            val filterEvent =
+                e.insert(
+                    NewEvent(
+                        name = "Filtering".toEventName(),
+                        description = "Two series, one closed.".toEventDescription(),
+                        startDate = Instant.now(),
+                        endDate = Instant.now().plusSeconds(3_600L),
+                        status = EventStatus.ACTIVE,
+                        eventStages = setOf(EventStage.PLAYOFFS),
+                    ),
+                    riotTournamentId = 4.toRiotTournamentId(),
+                ) ?: throw Exception("Failed to insert filtering event.")
+            val repeatPair = newSeries.copy(eventId = filterEvent.id, eventStage = EventStage.PLAYOFFS)
+            val open = repo.insert(repeatPair) ?: throw Exception("Failed to insert open series.")
+            val closed = repo.insert(repeatPair) ?: throw Exception("Failed to insert series to close.")
+            repo.complete(closed.id, Instant.parse("2026-07-14T23:12:04Z"))
+            val all = repo.getAllByEventId(filterEvent.id)
+
+            all
+                .filterByCompletion(
+                    SeriesQuery(teamIds = null, eventStage = null, completed = false),
+                ).map { it.id } shouldBe listOf(open.id)
+
+            all
+                .filterByCompletion(
+                    SeriesQuery(teamIds = null, eventStage = null, completed = true),
+                ).map { it.id } shouldBe listOf(closed.id)
+
+            all
+                .filterByCompletion(
+                    SeriesQuery(teamIds = null, eventStage = null),
+                ).map { it.id } shouldBe listOf(open.id, closed.id)
         }
 
         test("the V011 backfill completes series in ended events and leaves active ones alone") {

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
@@ -28,4 +28,5 @@ fun SeriesFilterParams.toQuery(): SeriesQuery =
     SeriesQuery(
         teamIds = teamIds?.map { it.toTeamId() },
         eventStage = stage,
+        completed = completed,
     )

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesFilterParams.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesFilterParams.kt
@@ -5,4 +5,5 @@ import com.lowbudgetlcs.domain.event.models.types.EventStage
 data class SeriesFilterParams(
     val teamIds: List<Int>?,
     val stage: EventStage?,
+    val completed: Boolean?,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventResources.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventResources.kt
@@ -34,6 +34,7 @@ class EventResources(
         val eventId: Int,
         val teamIds: List<Int>? = null,
         val stage: EventStage? = null,
+        val completed: Boolean? = null,
     )
 
     @Resource("{eventId}/series/{seriesId}")

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventRoutes.kt
@@ -79,6 +79,7 @@ fun Route.eventRoutesV1(
                 SeriesFilterParams(
                     teamIds = route.teamIds,
                     stage = route.stage,
+                    completed = route.completed,
                 )
             val event = eventService.getEventWithSeries(route.eventId.toEventId(), filter.toQuery())
 

--- a/src/main/kotlin/com/lowbudgetlcs/domain/event/EventService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/event/EventService.kt
@@ -14,6 +14,7 @@ import com.lowbudgetlcs.domain.event.models.toEventWithTeams
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.event.models.types.EventName
 import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.filterByCompletion
 import com.lowbudgetlcs.domain.series.models.filterByParticipants
 import com.lowbudgetlcs.domain.series.models.filterByStage
 import com.lowbudgetlcs.domain.team.models.TeamUpdate
@@ -60,7 +61,12 @@ class EventService(
         logger.debug("Getting event by '$id' (with series)...")
         query?.run { logger.debug("(Query: '$query')") }
         val event = getEvent(id)
-        val series = seriesRepo.getAllByEventId(id).filterByStage(query).filterByParticipants(query)
+        val series =
+            seriesRepo
+                .getAllByEventId(id)
+                .filterByStage(query)
+                .filterByParticipants(query)
+                .filterByCompletion(query)
         return event.toEventWithSeries(series)
     }
 

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -1,13 +1,11 @@
 package com.lowbudgetlcs.domain.series
 
 import com.lowbudgetlcs.domain.event.models.types.EventId
-import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.series.game.models.Game
 import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
-import com.lowbudgetlcs.domain.team.models.types.TeamId
 
 interface ISeriesService {
     /**
@@ -34,26 +32,6 @@ interface ISeriesService {
      * @throws com.lowbudgetlcs.repositories.DatabaseException when the underlying repository fails.
      */
     fun getSeries(id: SeriesId): Series
-
-    /**
-     * Return a series given two TeamIds and an event Stage. Will throw if multiple series match.
-     *
-     * @param eventId the event to search.
-     * @param teamId1 the first teamId to filter by.
-     * @param teamId2 the second teamId to filter by.
-     * @param eventStage the event stage to filter by.
-     * @return a series containing both team ids inside the specified event stage.
-     *
-     * @throws NoSuchElementException when no series is found.
-     * @throws com.lowbudgetlcs.repositories.DatabaseException if >1 series is found.
-     * @throws IllegalArgumentException when the teamIds are invalid.
-     */
-    fun findSeries(
-        eventId: EventId,
-        teamId1: TeamId,
-        teamId2: TeamId,
-        eventStage: EventStage,
-    ): Series
 
     /**
      * Remove a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -3,7 +3,6 @@ package com.lowbudgetlcs.domain.series
 import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
 import com.lowbudgetlcs.domain.event.models.toShortcode
 import com.lowbudgetlcs.domain.event.models.types.EventId
-import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.series.game.models.Game
 import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.models.NewSeries
@@ -53,30 +52,6 @@ class SeriesService(
     override fun getSeries(id: SeriesId): Series {
         logger.debug("Fetching series '$id'...")
         return seriesRepo.getById(id) ?: throw NoSuchElementException("Series not found")
-    }
-
-    override fun findSeries(
-        eventId: EventId,
-        teamId1: TeamId,
-        teamId2: TeamId,
-        eventStage: EventStage,
-    ): Series {
-        logger.debug("Fetching series containing ('$teamId1', '$teamId2') in stage '$eventStage'...")
-        eventRepo.getById(eventId) ?: throw NoSuchElementException("Event with id ${eventId.value} not found")
-        val t1 = teamRepo.getById(teamId1) ?: throw NoSuchElementException("Team with id '${teamId1.value}' not found")
-        val t2 = teamRepo.getById(teamId2) ?: throw NoSuchElementException("Team with id '${teamId2.value}' not found")
-        // TODO: Make eventId non-null.
-        require(t1.eventId == t2.eventId && t1.eventId != null) { "Teams are not in the same event." }
-
-        val series = seriesRepo.getAllByEventId(eventId).filter { it.eventStage == eventStage }
-            .filter { it.participants == listOf(teamId1, teamId2) }
-
-        if (series.size > 1) {
-            throw DatabaseException("More than one series matched this filter.")
-        } else if (series.isEmpty()) {
-            throw NoSuchElementException("No series matched this filter.")
-        }
-        return series.first()
     }
 
     override fun removeSeries(id: SeriesId) {

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Extensions.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Extensions.kt
@@ -10,6 +10,9 @@ fun Int.toSeriesId(): SeriesId = SeriesId(this)
 fun List<Series>.filterByStage(query: SeriesQuery?): List<Series> =
     this.filter { if (query?.eventStage == null) true else it.eventStage == query.eventStage }
 
+fun List<Series>.filterByCompletion(query: SeriesQuery?): List<Series> =
+    this.filter { if (query?.completed == null) true else it.completed == query.completed }
+
 fun List<Series>.filterByParticipants(query: SeriesQuery?): List<Series> {
     val participants = query?.teamIds
     return when {

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/SeriesQuery.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/SeriesQuery.kt
@@ -6,4 +6,5 @@ import com.lowbudgetlcs.domain.team.models.types.TeamId
 data class SeriesQuery(
     val teamIds: List<TeamId>?,
     val eventStage: EventStage?,
+    val completed: Boolean? = null,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
@@ -26,7 +26,7 @@ class SeriesRepository(
         selectSeries().where(SERIES.ID.eq(id.value)).fetchOne()?.let(::rowToSeries)
 
     override fun getAllByEventId(id: EventId): List<Series> =
-        selectSeries().where(SERIES.EVENT_ID.eq(id.value)).fetch().mapNotNull(::rowToSeries)
+        selectSeries().where(SERIES.EVENT_ID.eq(id.value)).orderBy(SERIES.ID).fetch().mapNotNull(::rowToSeries)
 
     override fun insert(newSeries: NewSeries): Series? {
         val id =

--- a/src/test/kotlin/services/SeriesServiceTest.kt
+++ b/src/test/kotlin/services/SeriesServiceTest.kt
@@ -11,6 +11,8 @@ import com.lowbudgetlcs.domain.event.models.types.EventStatus
 import com.lowbudgetlcs.domain.series.SeriesService
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.filterByCompletion
 import com.lowbudgetlcs.domain.series.models.toSeriesId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.Team
@@ -157,5 +159,54 @@ class SeriesServiceTest :
             ex.message shouldBe "Series not found"
 
             verify(exactly = 1) { seriesRepo.getById(id) }
+        }
+
+        val openSeries =
+            Series(
+                id = SeriesId(1),
+                eventId = EventId(1),
+                totalGames = 3,
+                participants = participatingTeams,
+                result = null,
+                eventStage = EventStage.PLAYOFFS,
+                completed = false,
+                completedAt = null,
+                reopenedAt = null,
+            )
+        val closedSeries =
+            openSeries.copy(
+                id = SeriesId(2),
+                completed = true,
+                completedAt = Instant.parse("2026-07-14T23:12:04Z"),
+            )
+        val bothSeries = listOf(openSeries, closedSeries)
+
+        "filterByCompletion returns only open series for completed = false" {
+            bothSeries.filterByCompletion(
+                SeriesQuery(teamIds = null, eventStage = null, completed = false),
+            ) shouldContainExactly listOf(openSeries)
+        }
+
+        "filterByCompletion returns only closed series for completed = true" {
+            bothSeries.filterByCompletion(
+                SeriesQuery(teamIds = null, eventStage = null, completed = true),
+            ) shouldContainExactly listOf(closedSeries)
+        }
+
+        "filterByCompletion is unfiltered when completed is omitted" {
+            bothSeries.filterByCompletion(
+                SeriesQuery(teamIds = null, eventStage = null),
+            ) shouldContainExactly bothSeries
+
+            bothSeries.filterByCompletion(null) shouldContainExactly bothSeries
+        }
+
+        "filterByCompletion distinguishes two series with identical participants and stage" {
+            openSeries.participants shouldBe closedSeries.participants
+            openSeries.eventStage shouldBe closedSeries.eventStage
+
+            bothSeries.filterByCompletion(
+                SeriesQuery(teamIds = null, eventStage = null, completed = false),
+            ) shouldContainExactly listOf(openSeries)
         }
     })


### PR DESCRIPTION
Closes #193. Part of #189.

> **Stacked on #206.** This PR targets `dev/192-feat-add-series-completion-state-v011`, not `release/1.4.0`, because it filters on the `completed` column that #206 adds. Review and merge #206 first; GitHub retargets this to `release/1.4.0` automatically when it lands.

Two independent read-side defects. Both had to go before any picker — Todd's or ours — can reliably choose between two series for the same team pair.

## 1. Ordering was nondeterministic

`getAllByEventId` had no `ORDER BY`. Postgres may return rows in a different order after any UPDATE — including the one that marks a series complete. `filterByStage` and `filterByParticipants` preserve whatever order they are handed, and Todd takes `seriesList[0]`, so "the first one" was not stable between two requests.

Fixed with `.orderBy(SERIES.ID)`. It is the only multi-row series fetch in the repository; `getById` returns one row.

**This is not a theoretical bug.** I verified the new test has teeth by removing `.orderBy(SERIES.ID)` and re-running:

```
WITHOUT orderBy: [FAIL] two series with the same pair and stage keep a stable id order across calls
```

Postgres really does reorder the rows after the completion UPDATE, so the test would have caught this and does not merely pass by luck on a small table.

## 2. No way to filter by completion

- `SeriesQuery` gains `completed: Boolean?`. **Nullable means unfiltered**, matching the existing `eventStage` and `teamIds`. The column itself is `NOT NULL`.
- `filterByCompletion` added to `domain/series/models/Extensions.kt` beside the other two, reusing their shape, and joined onto the chain in `EventService.getEventWithSeries`.
- Wired through `SeriesFilterParams` → `toQuery()` → `EventResources.ByIdSeries` → the handler in `EventRoutes.kt`.

Omitting the param stays unfiltered, so Stephen's existing event view is unaffected. This matches the `completed` query param already documented on `GET /api/v1/event/{eventId}/series` in #191.

## 3. `findSeries` deleted

It filtered with `it.participants == listOf(teamId1, teamId2)` — comparing a `Pair` to a `List`, which is never true. The filter always yielded empty, so the function **always threw `NoSuchElementException`**. It would not have been order-insensitive even if the types had matched.

Deleted along with its `ISeriesService` entry, as #193 permits. It had zero callers, no route exposed it, no test covered it, and the new `?completed=` filter covers the use case. Fixing it would have meant keeping a working function nobody calls. Three imports left unused by the removal were also dropped.

## Verification

Every test confirmed to have actually executed rather than inferred from a green build. **119 tests across all suites, 0 failures.**

New in `SeriesRepositoryTest`:

```
[pass] two series with the same pair and stage keep a stable id order across calls
[pass] completion filtering splits two series that are otherwise identical
```

New in `SeriesServiceTest`:

```
[pass] filterByCompletion returns only open series for completed = false
[pass] filterByCompletion returns only closed series for completed = true
[pass] filterByCompletion is unfiltered when completed is omitted
[pass] filterByCompletion distinguishes two series with identical participants and stage
```

- [x] itest: two series with the same pair and stage return in stable id order across repeated calls, including after one is updated
- [x] itest: `?completed=false` returns exactly the open one, `?completed=true` exactly the closed one, omitting the param returns both
- [x] Unit test in `SeriesServiceTest` covering two series with identical participants
- [x] `findSeries` is gone, with no dangling interface entry

### Lint

`ktlintItestSourceSetCheck` flagged three chain-continuation violations in the new test code; those are fixed. The remaining `make check` failures are pre-existing on `release/1.4.0` and untouched here — verified none of the files in this diff appear in any ktlint report. `detekt` passes.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
