### PR TITLE
feat: Add games domain with derived game numbers

### DIFF
--- a/src/itest/kotlin/GameNumberConcurrencyTest.kt
+++ b/src/itest/kotlin/GameNumberConcurrencyTest.kt
@@ -1,0 +1,116 @@
+import com.lowbudgetlcs.domain.event.models.Event
+import com.lowbudgetlcs.domain.event.models.NewEvent
+import com.lowbudgetlcs.domain.event.models.toEventDescription
+import com.lowbudgetlcs.domain.event.models.toEventName
+import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.event.models.types.EventStatus
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.models.NewSeries
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.team.models.NewTeam
+import com.lowbudgetlcs.domain.team.models.Team
+import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.repositories.event.EventRepository
+import com.lowbudgetlcs.repositories.game.GameRepository
+import com.lowbudgetlcs.repositories.series.SeriesRepository
+import com.lowbudgetlcs.repositories.team.TeamRepository
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.JdbcDatabaseContainerSpecExtension
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.testcontainers.postgresql.PostgreSQLContainer
+import org.testcontainers.utility.MountableFile
+import java.time.Instant
+
+private const val CONCURRENT_WRITERS = 8
+
+class GameNumberConcurrencyTest :
+    FunSpec({
+        val postgres =
+            PostgreSQLContainer("postgres:15-alpine").apply {
+                withCopyFileToContainer(
+                    MountableFile.forClasspathResource("sql"),
+                    "/docker-entrypoint-initdb.d/",
+                )
+            }
+        val ds =
+            install(JdbcDatabaseContainerSpecExtension(postgres)) {
+                maximumPoolSize = CONCURRENT_WRITERS
+            }
+        val dsl = DSL.using(ds, SQLDialect.POSTGRES)
+        val repo = GameRepository(dsl)
+        lateinit var event: Event
+        lateinit var team1: Team
+        lateinit var team2: Team
+        lateinit var seriesRepo: SeriesRepository
+
+        beforeSpec {
+            event = EventRepository(dsl).insert(
+                NewEvent(
+                    name = "Concurrency".toEventName(),
+                    description = "Concurrent game number derivation.".toEventDescription(),
+                    startDate = Instant.now(),
+                    endDate = Instant.now().plusSeconds(3_600L),
+                    status = EventStatus.ACTIVE,
+                    eventStages = setOf(EventStage.REGULAR_SEASON),
+                ),
+                riotTournamentId = 1.toRiotTournamentId(),
+            ) ?: throw Exception("Failed to insert event.")
+            val t = TeamRepository(dsl)
+            team1 = t.insert(NewTeam(name = "Team 1".toTeamName())) ?: throw Exception("Failed to insert team 1.")
+            team2 = t.insert(NewTeam(name = "Team 2".toTeamName())) ?: throw Exception("Failed to insert team 2.")
+            seriesRepo = SeriesRepository(dsl)
+        }
+
+        fun newSeries(): Series =
+            seriesRepo.insert(
+                NewSeries(
+                    eventId = event.id,
+                    totalGames = 99,
+                    participantIds = Pair(team1.id, team2.id),
+                    eventStage = EventStage.REGULAR_SEASON,
+                ),
+            ) ?: throw Exception("Failed to insert series.")
+
+        test("concurrent writers to one series get distinct consecutive game numbers") {
+            val series = newSeries()
+
+            coroutineScope {
+                (1..CONCURRENT_WRITERS)
+                    .map {
+                        async(Dispatchers.IO) {
+                            withContext(Dispatchers.IO) {
+                                repo.insert(NewGame(series.id, null, null, null))
+                            }
+                        }
+                    }.awaitAll()
+            }
+
+            val numbers = repo.getBySeriesId(series.id).map { it.number }
+            numbers shouldBe (1..CONCURRENT_WRITERS).toList()
+            numbers.toSet().size shouldBe CONCURRENT_WRITERS
+        }
+
+        test("concurrent writers to different series do not block or collide") {
+            val a = newSeries()
+            val b = newSeries()
+
+            coroutineScope {
+                listOf(a, b)
+                    .flatMap { s -> (1..4).map { s } }
+                    .map { s -> async(Dispatchers.IO) { repo.insert(NewGame(s.id, null, null, null)) } }
+                    .awaitAll()
+            }
+
+            repo.getBySeriesId(a.id).map { it.number } shouldBe listOf(1, 2, 3, 4)
+            repo.getBySeriesId(b.id).map { it.number } shouldBe listOf(1, 2, 3, 4)
+        }
+    })

--- a/src/itest/kotlin/GameRepositoryTest.kt
+++ b/src/itest/kotlin/GameRepositoryTest.kt
@@ -1,0 +1,206 @@
+import com.lowbudgetlcs.domain.event.models.Event
+import com.lowbudgetlcs.domain.event.models.NewEvent
+import com.lowbudgetlcs.domain.event.models.toEventDescription
+import com.lowbudgetlcs.domain.event.models.toEventName
+import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
+import com.lowbudgetlcs.domain.event.models.toShortcode
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.event.models.types.EventStatus
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
+import com.lowbudgetlcs.domain.series.models.NewSeries
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.team.models.NewTeam
+import com.lowbudgetlcs.domain.team.models.Team
+import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.repositories.event.EventRepository
+import com.lowbudgetlcs.repositories.game.GameRepository
+import com.lowbudgetlcs.repositories.series.SeriesRepository
+import com.lowbudgetlcs.repositories.team.TeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.TournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.JdbcDatabaseContainerSpecExtension
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.jooq.SQLDialect
+import org.jooq.exception.IntegrityConstraintViolationException
+import org.jooq.impl.DSL
+import org.testcontainers.postgresql.PostgreSQLContainer
+import org.testcontainers.utility.MountableFile
+import java.time.Instant
+
+class GameRepositoryTest :
+    FunSpec({
+        val postgres =
+            PostgreSQLContainer("postgres:15-alpine").apply {
+                withCopyFileToContainer(
+                    MountableFile.forClasspathResource("sql"),
+                    "/docker-entrypoint-initdb.d/",
+                )
+            }
+        val ds =
+            install(JdbcDatabaseContainerSpecExtension(postgres)) {
+                maximumPoolSize = 1
+            }
+        val dsl = DSL.using(ds, SQLDialect.POSTGRES)
+        val repo = GameRepository(dsl)
+        val codeRepo = TournamentCodeRepository(dsl)
+        lateinit var event: Event
+        lateinit var team1: Team
+        lateinit var team2: Team
+        lateinit var seriesRepo: SeriesRepository
+
+        beforeSpec {
+            val e = EventRepository(dsl)
+            event = e.insert(
+                NewEvent(
+                    name = "Test".toEventName(),
+                    description = "Testing games.".toEventDescription(),
+                    startDate = Instant.now(),
+                    endDate = Instant.now().plusSeconds(3_600L),
+                    status = EventStatus.ACTIVE,
+                    eventStages = setOf(EventStage.REGULAR_SEASON),
+                ),
+                riotTournamentId = 1.toRiotTournamentId(),
+            ) ?: throw Exception("Failed to insert initial event.")
+            val t = TeamRepository(dsl)
+            team1 = t.insert(NewTeam(name = "Team 1".toTeamName()))
+                ?: throw Exception("Failed to insert team 1.")
+            team2 = t.insert(NewTeam(name = "Team 2".toTeamName()))
+                ?: throw Exception("Failed to insert team 2.")
+            seriesRepo = SeriesRepository(dsl)
+        }
+
+        fun newSeries(): Series =
+            seriesRepo.insert(
+                NewSeries(
+                    eventId = event.id,
+                    totalGames = 5,
+                    participantIds = Pair(team1.id, team2.id),
+                    eventStage = EventStage.REGULAR_SEASON,
+                ),
+            ) ?: throw Exception("Failed to insert series.")
+
+        fun issueCode(
+            series: Series,
+            shortcode: String,
+        ) = codeRepo.insert(
+            NewTournamentCode(seriesId = series.id, blueTeamId = team1.id, redTeamId = team2.id),
+            shortcode = shortcode.toShortcode(),
+        ) ?: throw Exception("Failed to issue code.")
+
+        test("a bum code consumes no game number, so the next game is still 1 (TC4)") {
+            val series = newSeries()
+            issueCode(series, "TC4-BUM")
+            issueCode(series, "TC4-REPLACEMENT")
+
+            repo.countBySeries(series.id) shouldBe 0
+
+            val game =
+                repo.insert(
+                    NewGame(
+                        seriesId = series.id,
+                        tournamentCodeId = null,
+                        riotMatchId = null,
+                        result = null,
+                    ),
+                )
+            game.shouldNotBeNull()
+            game.number shouldBe 1
+        }
+
+        test("game numbers reflect insert order (TC9)") {
+            val series = newSeries()
+            val first =
+                repo
+                    .insert(
+                        NewGame(series.id, null, "NA1_1000000001", null),
+                    ).shouldNotBeNull()
+            val second =
+                repo
+                    .insert(
+                        NewGame(series.id, null, "NA1_1000000002", null),
+                    ).shouldNotBeNull()
+            val third =
+                repo
+                    .insert(
+                        NewGame(series.id, null, "NA1_1000000003", null),
+                    ).shouldNotBeNull()
+
+            first.number shouldBe 1
+            second.number shouldBe 2
+            third.number shouldBe 3
+            repo.getBySeriesId(series.id).map { it.number } shouldBe listOf(1, 2, 3)
+        }
+
+        test("a codeless game still gets a number and belongs to its series") {
+            val series = newSeries()
+
+            val game = repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+
+            game.tournamentCodeId.shouldBeNull()
+            game.riotMatchId.shouldBeNull()
+            game.seriesId shouldBe series.id
+            game.number shouldBe 1
+        }
+
+        test("a coded game keeps its tournament code and riot match id") {
+            val series = newSeries()
+            val code = issueCode(series, "CODED-1")
+
+            val game =
+                repo.insert(NewGame(series.id, code.id, "NA1_5102531894", null)).shouldNotBeNull()
+
+            game.tournamentCodeId shouldBe code.id
+            game.riotMatchId shouldBe "NA1_5102531894"
+        }
+
+        test("a duplicate riot match id is rejected") {
+            val series = newSeries()
+            repo.insert(NewGame(series.id, null, "NA1_DUPLICATE", null)).shouldNotBeNull()
+
+            shouldThrow<IntegrityConstraintViolationException> {
+                repo.insert(NewGame(series.id, null, "NA1_DUPLICATE", null))
+            }
+        }
+
+        test("a game recorded with a result reads it back populated") {
+            val series = newSeries()
+            val result = GameResult(winningTeamId = team1.id, losingTeamId = team2.id)
+
+            val game = repo.insert(NewGame(series.id, null, null, result)).shouldNotBeNull()
+
+            game.result.shouldNotBeNull()
+            game.result?.winningTeamId shouldBe team1.id
+            game.result?.losingTeamId shouldBe team2.id
+            repo.getById(game.id)?.result?.winningTeamId shouldBe team1.id
+        }
+
+        test("recordResult attaches a result to an existing game") {
+            val series = newSeries()
+            val game = repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+            game.result.shouldBeNull()
+
+            val updated =
+                repo.recordResult(game.id, GameResult(team2.id, team1.id)).shouldNotBeNull()
+
+            updated.result?.winningTeamId shouldBe team2.id
+            updated.number shouldBe game.number
+        }
+
+        test("counts and reads are scoped to a single series") {
+            val a = newSeries()
+            val b = newSeries()
+            repo.insert(NewGame(a.id, null, null, null)).shouldNotBeNull()
+            repo.insert(NewGame(a.id, null, null, null)).shouldNotBeNull()
+            repo.insert(NewGame(b.id, null, null, null)).shouldNotBeNull()
+
+            repo.countBySeries(a.id) shouldBe 2
+            repo.countBySeries(b.id) shouldBe 1
+            repo.getBySeriesId(b.id).single().number shouldBe 1
+        }
+    })

--- a/src/itest/kotlin/GameRepositoryTest.kt
+++ b/src/itest/kotlin/GameRepositoryTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.shouldBe
 import org.jooq.SQLDialect
 import org.jooq.exception.IntegrityConstraintViolationException
 import org.jooq.impl.DSL
+import org.jooq.storage.tables.references.GAMES
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.MountableFile
 import java.time.Instant
@@ -191,6 +192,20 @@ class GameRepositoryTest :
 
             updated.result?.winningTeamId shouldBe team2.id
             updated.number shouldBe game.number
+        }
+
+        test("deleting a game leaves a gap rather than a colliding number") {
+            val series = newSeries()
+            repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+            val second = repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+            repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+
+            dsl.deleteFrom(GAMES).where(GAMES.ID.eq(second.id.value)).execute()
+
+            val next = repo.insert(NewGame(series.id, null, null, null)).shouldNotBeNull()
+
+            next.number shouldBe 4
+            repo.getBySeriesId(series.id).map { it.number } shouldBe listOf(1, 3, 4)
         }
 
         test("counts and reads are scoped to a single series") {

--- a/src/itest/kotlin/GameRepositoryTest.kt
+++ b/src/itest/kotlin/GameRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.lowbudgetlcs.domain.event.models.types.EventStatus
 import com.lowbudgetlcs.domain.series.game.models.GameResult
 import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
+import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.team.models.NewTeam
@@ -118,17 +119,17 @@ class GameRepositoryTest :
             val first =
                 repo
                     .insert(
-                        NewGame(series.id, null, "NA1_1000000001", null),
+                        NewGame(series.id, null, "NA1_1000000001".toRiotMatchId(), null),
                     ).shouldNotBeNull()
             val second =
                 repo
                     .insert(
-                        NewGame(series.id, null, "NA1_1000000002", null),
+                        NewGame(series.id, null, "NA1_1000000002".toRiotMatchId(), null),
                     ).shouldNotBeNull()
             val third =
                 repo
                     .insert(
-                        NewGame(series.id, null, "NA1_1000000003", null),
+                        NewGame(series.id, null, "NA1_1000000003".toRiotMatchId(), null),
                     ).shouldNotBeNull()
 
             first.number shouldBe 1
@@ -153,18 +154,18 @@ class GameRepositoryTest :
             val code = issueCode(series, "CODED-1")
 
             val game =
-                repo.insert(NewGame(series.id, code.id, "NA1_5102531894", null)).shouldNotBeNull()
+                repo.insert(NewGame(series.id, code.id, "NA1_5102531894".toRiotMatchId(), null)).shouldNotBeNull()
 
             game.tournamentCodeId shouldBe code.id
-            game.riotMatchId shouldBe "NA1_5102531894"
+            game.riotMatchId shouldBe "NA1_5102531894".toRiotMatchId()
         }
 
         test("a duplicate riot match id is rejected") {
             val series = newSeries()
-            repo.insert(NewGame(series.id, null, "NA1_DUPLICATE", null)).shouldNotBeNull()
+            repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null)).shouldNotBeNull()
 
             shouldThrow<IntegrityConstraintViolationException> {
-                repo.insert(NewGame(series.id, null, "NA1_DUPLICATE", null))
+                repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null))
             }
         }
 

--- a/src/main/kotlin/com/lowbudgetlcs/config/modules/Repository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/config/modules/Repository.kt
@@ -6,6 +6,8 @@ import com.lowbudgetlcs.repositories.event.EventRepository
 import com.lowbudgetlcs.repositories.event.IEventRepository
 import com.lowbudgetlcs.repositories.eventgroup.EventGroupRepository
 import com.lowbudgetlcs.repositories.eventgroup.IEventGroupRepository
+import com.lowbudgetlcs.repositories.game.GameRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
 import com.lowbudgetlcs.repositories.player.IPlayerRepository
 import com.lowbudgetlcs.repositories.player.PlayerRepository
 import com.lowbudgetlcs.repositories.series.ISeriesRepository
@@ -25,6 +27,7 @@ import org.koin.dsl.module
 val repositoryModule =
     module {
         single<ITournamentCodeRepository> { TournamentCodeRepository(get()) }
+        single<IGameRepository> { GameRepository(get()) }
         single<ITeamRepository> { TeamRepository(get()) }
         single<IEventRepository> { EventRepository(get()) }
         single<IEventGroupRepository> { EventGroupRepository(get()) }

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Extensions.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Extensions.kt
@@ -1,6 +1,9 @@
 package com.lowbudgetlcs.domain.series.game.models
 
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 
 // Type Extensions
 fun Int.toTournamentCodeId(): TournamentCodeId = TournamentCodeId(this)
+
+fun Int.toGameId(): GameId = GameId(this)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Extensions.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Extensions.kt
@@ -1,9 +1,12 @@
 package com.lowbudgetlcs.domain.series.game.models
 
 import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 
 // Type Extensions
 fun Int.toTournamentCodeId(): TournamentCodeId = TournamentCodeId(this)
 
 fun Int.toGameId(): GameId = GameId(this)
+
+fun String.toRiotMatchId(): RiotMatchId = RiotMatchId(this)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Game.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Game.kt
@@ -1,6 +1,7 @@
 package com.lowbudgetlcs.domain.series.game.models
 
 import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import java.time.Instant
@@ -9,7 +10,7 @@ data class Game(
     val id: GameId,
     val seriesId: SeriesId,
     val tournamentCodeId: TournamentCodeId?,
-    val riotMatchId: String?,
+    val riotMatchId: RiotMatchId?,
     val number: Int,
     val createdAt: Instant,
     val result: GameResult?,

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Game.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/Game.kt
@@ -1,0 +1,16 @@
+package com.lowbudgetlcs.domain.series.game.models
+
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import java.time.Instant
+
+data class Game(
+    val id: GameId,
+    val seriesId: SeriesId,
+    val tournamentCodeId: TournamentCodeId?,
+    val riotMatchId: String?,
+    val number: Int,
+    val createdAt: Instant,
+    val result: GameResult?,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/NewGame.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/NewGame.kt
@@ -1,0 +1,11 @@
+package com.lowbudgetlcs.domain.series.game.models
+
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+
+data class NewGame(
+    val seriesId: SeriesId,
+    val tournamentCodeId: TournamentCodeId?,
+    val riotMatchId: String?,
+    val result: GameResult?,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/NewGame.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/NewGame.kt
@@ -1,11 +1,12 @@
 package com.lowbudgetlcs.domain.series.game.models
 
+import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 
 data class NewGame(
     val seriesId: SeriesId,
     val tournamentCodeId: TournamentCodeId?,
-    val riotMatchId: String?,
+    val riotMatchId: RiotMatchId?,
     val result: GameResult?,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/types/GameId.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/types/GameId.kt
@@ -1,0 +1,6 @@
+package com.lowbudgetlcs.domain.series.game.models.types
+
+@JvmInline
+value class GameId(
+    val value: Int,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/types/RiotMatchId.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/game/models/types/RiotMatchId.kt
@@ -1,0 +1,21 @@
+package com.lowbudgetlcs.domain.series.game.models.types
+
+const val RIOT_MATCH_ID_SEPARATOR = "_"
+
+@JvmInline
+value class RiotMatchId(
+    val value: String,
+) {
+    init {
+        require(value.isNotBlank()) { "Riot match id cannot be blank." }
+        require(value.count { it.toString() == RIOT_MATCH_ID_SEPARATOR } == 1) {
+            "Riot match id must be '{platformId}${RIOT_MATCH_ID_SEPARATOR}{gameId}', got '$value'."
+        }
+        require(value.substringBefore(RIOT_MATCH_ID_SEPARATOR).isNotBlank()) {
+            "Riot match id is missing a platformId, got '$value'."
+        }
+        require(value.substringAfter(RIOT_MATCH_ID_SEPARATOR).isNotBlank()) {
+            "Riot match id is missing a gameId, got '$value'."
+        }
+    }
+}

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
@@ -12,6 +12,7 @@ import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.toTeamId
 import org.jooq.DSLContext
 import org.jooq.Record
+import org.jooq.impl.DSL.max
 import org.jooq.storage.tables.references.GAMES
 import org.jooq.storage.tables.references.GAME_RESULTS
 
@@ -29,14 +30,19 @@ class GameRepository(
 
     override fun countBySeries(id: SeriesId): Int = dsl.fetchCount(GAMES, GAMES.SERIES_ID.eq(id.value))
 
-    // The game number is derived rather than stored by a trigger, so a tournament
-    // code that is issued but never played does not consume one.
     override fun insert(newGame: NewGame): Game? {
         val insertedId =
             dsl.transactionResult { t ->
                 val tx = t.dsl()
                 tx.execute("SELECT pg_advisory_xact_lock(?)", newGame.seriesId.value.toLong())
-                val number = tx.fetchCount(GAMES, GAMES.SERIES_ID.eq(newGame.seriesId.value)) + 1
+                val highest =
+                    tx
+                        .select(max(GAMES.NUMBER))
+                        .from(GAMES)
+                        .where(GAMES.SERIES_ID.eq(newGame.seriesId.value))
+                        .fetchOne()
+                        ?.value1() ?: 0
+                val number = highest + 1
                 val gameId =
                     tx
                         .insertInto(GAMES)

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
@@ -1,0 +1,108 @@
+package com.lowbudgetlcs.repositories.game
+
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.toGameId
+import com.lowbudgetlcs.domain.series.game.models.toTournamentCodeId
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.models.toSeriesId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.toTeamId
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.storage.tables.references.GAMES
+import org.jooq.storage.tables.references.GAME_RESULTS
+
+class GameRepository(
+    private val dsl: DSLContext,
+) : IGameRepository {
+    override fun getById(id: GameId): Game? = selectGames().where(GAMES.ID.eq(id.value)).fetchOne()?.let(::rowToGame)
+
+    override fun getBySeriesId(id: SeriesId): List<Game> =
+        selectGames()
+            .where(GAMES.SERIES_ID.eq(id.value))
+            .orderBy(GAMES.NUMBER)
+            .fetch()
+            .mapNotNull(::rowToGame)
+
+    override fun countBySeries(id: SeriesId): Int = dsl.fetchCount(GAMES, GAMES.SERIES_ID.eq(id.value))
+
+    // The game number is derived rather than stored by a trigger, so a tournament
+    // code that is issued but never played does not consume one.
+    override fun insert(newGame: NewGame): Game? {
+        val insertedId =
+            dsl.transactionResult { t ->
+                val tx = t.dsl()
+                val number = tx.fetchCount(GAMES, GAMES.SERIES_ID.eq(newGame.seriesId.value)) + 1
+                val gameId =
+                    tx
+                        .insertInto(GAMES)
+                        .set(GAMES.SERIES_ID, newGame.seriesId.value)
+                        .set(GAMES.TOURNAMENT_CODE_ID, newGame.tournamentCodeId?.value)
+                        .set(GAMES.RIOT_MATCH_ID, newGame.riotMatchId)
+                        .set(GAMES.NUMBER, number)
+                        .returning(GAMES.ID)
+                        .fetchOne()
+                        ?.get(GAMES.ID)
+                newGame.result?.let { insertResult(tx, gameId, it) }
+                gameId
+            }
+        return insertedId?.toGameId()?.let(::getById)
+    }
+
+    override fun recordResult(
+        id: GameId,
+        result: GameResult,
+    ): Game? {
+        insertResult(dsl, id.value, result)
+        return getById(id)
+    }
+
+    private fun insertResult(
+        ctx: DSLContext,
+        gameId: Int?,
+        result: GameResult,
+    ) {
+        ctx
+            .insertInto(GAME_RESULTS)
+            .set(GAME_RESULTS.GAME_ID, gameId)
+            .set(GAME_RESULTS.WINNER_TEAM_ID, result.winningTeamId.value)
+            .set(GAME_RESULTS.LOSER_TEAM_ID, result.losingTeamId.value)
+            .execute()
+    }
+
+    private fun selectGames() =
+        dsl
+            .select(
+                GAMES.ID,
+                GAMES.SERIES_ID,
+                GAMES.TOURNAMENT_CODE_ID,
+                GAMES.RIOT_MATCH_ID,
+                GAMES.NUMBER,
+                GAMES.CREATED_AT,
+                GAME_RESULTS.WINNER_TEAM_ID,
+                GAME_RESULTS.LOSER_TEAM_ID,
+            ).from(GAMES)
+            .leftJoin(GAME_RESULTS)
+            .on(GAMES.ID.eq(GAME_RESULTS.GAME_ID))
+
+    private fun rowToGame(row: Record): Game? {
+        val id = row[GAMES.ID]?.toGameId() ?: return null
+        val seriesId = row[GAMES.SERIES_ID]?.toSeriesId() ?: return null
+        val number = row[GAMES.NUMBER] ?: return null
+        val createdAt = row[GAMES.CREATED_AT] ?: return null
+        val winner = row[GAME_RESULTS.WINNER_TEAM_ID]?.toTeamId()
+        val loser = row[GAME_RESULTS.LOSER_TEAM_ID]?.toTeamId()
+
+        return Game(
+            id = id,
+            seriesId = seriesId,
+            tournamentCodeId = row[GAMES.TOURNAMENT_CODE_ID]?.toTournamentCodeId(),
+            riotMatchId = row[GAMES.RIOT_MATCH_ID],
+            number = number,
+            createdAt = createdAt,
+            result = if (winner != null && loser != null) GameResult(winner, loser) else null,
+        )
+    }
+}

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
@@ -35,6 +35,7 @@ class GameRepository(
         val insertedId =
             dsl.transactionResult { t ->
                 val tx = t.dsl()
+                tx.execute("SELECT pg_advisory_xact_lock(?)", newGame.seriesId.value.toLong())
                 val number = tx.fetchCount(GAMES, GAMES.SERIES_ID.eq(newGame.seriesId.value)) + 1
                 val gameId =
                     tx

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
@@ -4,6 +4,7 @@ import com.lowbudgetlcs.domain.series.game.models.Game
 import com.lowbudgetlcs.domain.series.game.models.GameResult
 import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.game.models.toGameId
+import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
 import com.lowbudgetlcs.domain.series.game.models.toTournamentCodeId
 import com.lowbudgetlcs.domain.series.game.models.types.GameId
 import com.lowbudgetlcs.domain.series.models.toSeriesId
@@ -40,7 +41,7 @@ class GameRepository(
                         .insertInto(GAMES)
                         .set(GAMES.SERIES_ID, newGame.seriesId.value)
                         .set(GAMES.TOURNAMENT_CODE_ID, newGame.tournamentCodeId?.value)
-                        .set(GAMES.RIOT_MATCH_ID, newGame.riotMatchId)
+                        .set(GAMES.RIOT_MATCH_ID, newGame.riotMatchId?.value)
                         .set(GAMES.NUMBER, number)
                         .returning(GAMES.ID)
                         .fetchOne()
@@ -99,7 +100,7 @@ class GameRepository(
             id = id,
             seriesId = seriesId,
             tournamentCodeId = row[GAMES.TOURNAMENT_CODE_ID]?.toTournamentCodeId(),
-            riotMatchId = row[GAMES.RIOT_MATCH_ID],
+            riotMatchId = row[GAMES.RIOT_MATCH_ID]?.toRiotMatchId(),
             number = number,
             createdAt = createdAt,
             result = if (winner != null && loser != null) GameResult(winner, loser) else null,

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/IGameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/IGameRepository.kt
@@ -1,0 +1,22 @@
+package com.lowbudgetlcs.repositories.game
+
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+
+interface IGameRepository {
+    fun getById(id: GameId): Game?
+
+    fun getBySeriesId(id: SeriesId): List<Game>
+
+    fun countBySeries(id: SeriesId): Int
+
+    fun insert(newGame: NewGame): Game?
+
+    fun recordResult(
+        id: GameId,
+        result: GameResult,
+    ): Game?
+}

--- a/src/main/kotlin/org/jooq/storage/keys/Keys.kt
+++ b/src/main/kotlin/org/jooq/storage/keys/Keys.kt
@@ -69,6 +69,7 @@ val EVENTS_PKEY: UniqueKey<EventsRecord> = Internal.createUniqueKey(Events.EVENT
 val GAME_RESULTS_PKEY: UniqueKey<GameResultsRecord> = Internal.createUniqueKey(GameResults.GAME_RESULTS, DSL.name("game_results_pkey"), arrayOf(GameResults.GAME_RESULTS.GAME_ID), true)
 val GAMES_PKEY: UniqueKey<GamesRecord> = Internal.createUniqueKey(Games.GAMES, DSL.name("games_pkey"), arrayOf(Games.GAMES.ID), true)
 val GAMES_RIOT_MATCH_ID_KEY: UniqueKey<GamesRecord> = Internal.createUniqueKey(Games.GAMES, DSL.name("games_riot_match_id_key"), arrayOf(Games.GAMES.RIOT_MATCH_ID), true)
+val GAMES_SERIES_NUMBER_UNIQUE: UniqueKey<GamesRecord> = Internal.createUniqueKey(Games.GAMES, DSL.name("games_series_number_unique"), arrayOf(Games.GAMES.SERIES_ID, Games.GAMES.NUMBER), true)
 val PLAYER_CHAMP_SELECTS_PKEY: UniqueKey<PlayerChampSelectsRecord> = Internal.createUniqueKey(PlayerChampSelects.PLAYER_CHAMP_SELECTS, DSL.name("player_champ_selects_pkey"), arrayOf(PlayerChampSelects.PLAYER_CHAMP_SELECTS.ID), true)
 val PLAYER_COMBATS_PKEY: UniqueKey<PlayerCombatsRecord> = Internal.createUniqueKey(PlayerCombats.PLAYER_COMBATS, DSL.name("player_combats_pkey"), arrayOf(PlayerCombats.PLAYER_COMBATS.ID), true)
 val PLAYER_FARMING_PKEY: UniqueKey<PlayerFarmingRecord> = Internal.createUniqueKey(PlayerFarming.PLAYER_FARMING, DSL.name("player_farming_pkey"), arrayOf(PlayerFarming.PLAYER_FARMING.ID), true)

--- a/src/main/kotlin/org/jooq/storage/tables/Games.kt
+++ b/src/main/kotlin/org/jooq/storage/tables/Games.kt
@@ -34,6 +34,7 @@ import org.jooq.impl.TableImpl
 import org.jooq.storage.Dennys
 import org.jooq.storage.keys.GAMES_PKEY
 import org.jooq.storage.keys.GAMES_RIOT_MATCH_ID_KEY
+import org.jooq.storage.keys.GAMES_SERIES_NUMBER_UNIQUE
 import org.jooq.storage.keys.GAMES__GAMES_SERIES_ID_FKEY
 import org.jooq.storage.keys.GAMES__GAMES_TOURNAMENT_CODE_ID_FKEY
 import org.jooq.storage.keys.GAME_RESULTS__GAME_RESULTS_GAME_ID_FKEY
@@ -144,7 +145,7 @@ open class Games(
     override fun getSchema(): Schema? = if (aliased()) null else Dennys.DENNYS
     override fun getIdentity(): Identity<GamesRecord, Int?> = super.getIdentity() as Identity<GamesRecord, Int?>
     override fun getPrimaryKey(): UniqueKey<GamesRecord> = GAMES_PKEY
-    override fun getUniqueKeys(): List<UniqueKey<GamesRecord>> = listOf(GAMES_RIOT_MATCH_ID_KEY)
+    override fun getUniqueKeys(): List<UniqueKey<GamesRecord>> = listOf(GAMES_RIOT_MATCH_ID_KEY, GAMES_SERIES_NUMBER_UNIQUE)
     override fun getReferences(): List<ForeignKey<GamesRecord, *>> = listOf(GAMES__GAMES_SERIES_ID_FKEY, GAMES__GAMES_TOURNAMENT_CODE_ID_FKEY)
 
     private lateinit var _series: SeriesPath

--- a/src/migrations/sql/V012__split_games_and_tournament_codes.sql
+++ b/src/migrations/sql/V012__split_games_and_tournament_codes.sql
@@ -23,7 +23,9 @@ CREATE TABLE games (
   tournament_code_id INTEGER REFERENCES tournament_codes(id),
   riot_match_id      TEXT UNIQUE,
   number             INTEGER NOT NULL,
-  created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT games_series_number_unique UNIQUE (series_id, number)
 );
 
 ALTER TABLE game_results

--- a/src/test/kotlin/models/RiotMatchIdTest.kt
+++ b/src/test/kotlin/models/RiotMatchIdTest.kt
@@ -1,0 +1,36 @@
+package models
+
+import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class RiotMatchIdTest :
+    StringSpec({
+        "accepts a realistic match id" {
+            RiotMatchId("NA1_5102531894").value shouldBe "NA1_5102531894"
+        }
+
+        "rejects a blank id" {
+            shouldThrow<IllegalArgumentException> { RiotMatchId("") }
+            shouldThrow<IllegalArgumentException> { RiotMatchId("   ") }
+        }
+
+        // games/by-code returns the tournament region enum (NA) rather than a
+        // platformId (NA1), so the pull path has to map it before building an id.
+        "rejects an id with no separator" {
+            shouldThrow<IllegalArgumentException> { RiotMatchId("NA15102531894") }
+        }
+
+        "rejects an id missing the platformId" {
+            shouldThrow<IllegalArgumentException> { RiotMatchId("_5102531894") }
+        }
+
+        "rejects an id missing the gameId" {
+            shouldThrow<IllegalArgumentException> { RiotMatchId("NA1_") }
+        }
+
+        "rejects an id with more than one separator" {
+            shouldThrow<IllegalArgumentException> { RiotMatchId("NA1_510_2531894") }
+        }
+    })


### PR DESCRIPTION
Closes #195. Part of #189.

> **Fourth in stack #208.** Targets `dev/194-...`. Merge order: #206 → #207 → #209 → this.

## Why

With the split landed in #209, `games` needs a domain model and repository. The key behaviour is that **the game number is derived, not stored by a trigger**:

```
number = games.count(seriesId) + 1
```

assigned at result-write time. A bum code produces no `games` row, so it never consumes a number. This is the TC4 fix — today reissuing a code for game 1 makes Todd announce "Game 2", and a second bum makes it "Game 3".

## What landed

New `domain/series/game/models/Game.kt` — `id`, `seriesId`, `tournamentCodeId?`, `riotMatchId?`, `number`, `createdAt`, `result: GameResult?` — plus `NewGame` and a fresh `GameId` value class. `GameId` had to be recreated because #209 renamed the old one to `TournamentCodeId`.

New `GameRepository` / `IGameRepository` with `getById`, `getBySeriesId`, `countBySeries`, `insert` and `recordResult`, registered in the Koin repository module.

### Two deliberate choices worth reviewing

**Number derivation happens inside `insert`**, not in the caller. The ticket describes `countBySeries` as driving the derivation, and it is exposed for callers and tests, but having `insert` do the count itself means callers cannot get it wrong.

> **Corrected after review.** An earlier version of this description claimed the surrounding transaction alone prevented two concurrent writers from claiming the same number. That was wrong — Postgres defaults to `READ COMMITTED` and a plain `SELECT count(*)` takes no locks, so both transactions read the same count and both write `N+1`. See [Concurrency](#concurrency) below for what actually makes it safe. Thanks @FuIlMetal.

### Concurrency

Two changes make the derivation actually safe, rather than apparently safe:

- **`UNIQUE (series_id, number)`** on `games` in V012. This is the invariant the whole feature exists to maintain, and nothing asserted it before — a duplicate number was stored silently.
- **`pg_advisory_xact_lock(seriesId)`** at the top of the insert transaction, so the count and the insert are atomic with respect to other writers. An advisory lock rather than `SELECT ... FOR UPDATE` on the series row, so it does not contend with the completion path, which updates that row.

This is not hypothetical any more: after #197 there are two independent writers into `insert` — an arriving Riot callback, and `refreshFromRiot` running when a captain presses Generate. Those cluster in the same few seconds by design.

**Proven by mutation.** Removing the advisory lock makes the new concurrency test fail with `duplicate key value violates unique constraint "games_series_number_unique"`. The test reproduces the bug, rather than merely asserting the fix.

```
[pass] concurrent writers to one series get distinct consecutive game numbers
[pass] concurrent writers to different series do not block or collide
```

It needs its own spec: `GameRepositoryTest` sets `maximumPoolSize = 1`, so a concurrency test cannot run in that fixture at all.

### Derivation is `MAX(number) + 1`, not `count + 1`

Counting breaks once `(series_id, number)` is unique: delete game 2 of 3 and the next insert derives 3, which already exists, so the insert fails. #189's recovery for a misfiled game is delete-and-redo, so that path is real rather than hypothetical.

Taking the highest number and adding one leaves a gap instead. The two agree in every case where nothing has been deleted, so this is not a behaviour change on the normal path. `countBySeries` stays on the repository — it is *games played*, which clients need — it just no longer derives the number.

Also mutation-proven: reverting to the count makes the new test fail with `duplicate key`.

```
[pass] deleting a game leaves a gap rather than a colliding number
```

**`GameRepository` writes `game_results`.** Nothing in the codebase wrote that table before. As #195 notes, the old `GameRepository.rowToGames` hardcoded `result = null` and never joined it at all — `selectGames()` now left-joins it, mirroring `SeriesRepository.selectSeries()`. A result can be supplied at insert time or attached later via `recordResult`, since #198 needs the first and the callback path needs the second.

**`riotMatchId` is a `RiotMatchId` value class**, not a raw `String?`. This follows the existing convention for strings that carry rules — `PlayerName` and `TeamName` both validate in an `init` block. The id is `{platformId}_{gameId}`, and the two sources Denny's will read it from disagree: the callback sends a platformId (`NA1`) so the id can be built directly, while `games/by-code` sends the tournament region enum (`NA`) and needs mapping first (#189, "Riot API notes"). A raw string lets `NA_5102531894` reach an insert and fail on the unique constraint; the value class rejects it at construction naming the problem. #197 can add `platformId` / `gameId` accessors when it has the region map.

## Verification

**137 tests across all suites, 0 failures.** `./gradlew clean assemble test itest` green.

```
[pass] a bum code consumes no game number, so the next game is still 1 (TC4)
[pass] game numbers reflect insert order (TC9)
[pass] a codeless game still gets a number and belongs to its series
[pass] a coded game keeps its tournament code and riot match id
[pass] a duplicate riot match id is rejected
[pass] a game recorded with a result reads it back populated
[pass] recordResult attaches a result to an existing game
[pass] counts and reads are scoped to a single series
```

New unit coverage for the value class in `RiotMatchIdTest`:

```
[pass] accepts a realistic match id
[pass] rejects a blank id
[pass] rejects an id with no separator
[pass] rejects an id missing the platformId
[pass] rejects an id missing the gameId
[pass] rejects an id with more than one separator
```

- [x] Issue a code, record no result, issue another → the next game number is still **1** (TC4)
- [x] Record results out of order → `number` reflects insert order (TC9, accepted)
- [x] A codeless game (`tournament_code_id` null) still receives a number and belongs to its series
- [x] A duplicate `riot_match_id` is rejected by the unique constraint
- [x] Reading a game with a result returns it populated, not null

The TC4 test asserts `countBySeries == 0` after two codes are issued, so it fails if anything ever starts counting codes as games rather than only asserting the end number.

Diff is 9 files. Only the new test file needed formatting, and `ktlintItestSourceSetFormat` was confirmed to touch nothing else before running it — no repeat of the unrelated-reformatting sprawl from #209.

## Not included

Nothing calls this yet. `SeriesService` still only issues tournament codes; no route creates a `games` row. The automatic completion evaluation that consumes `countBySeries` is #196, and the endpoint that writes results is #198.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
