### PR TITLE
feat: Auto-close series on result write

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/config/modules/Service.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/config/modules/Service.kt
@@ -25,7 +25,7 @@ val serviceModule =
         single<IEventService> { EventService(get(), get(), get(), get()) }
         single<IEventGroupService> { EventGroupService(get(), get()) }
         single<IPlayerService> { PlayerService(get(), get(), get()) }
-        single<ISeriesService> { SeriesService(get(), get(), get(), get(), get()) }
+        single<ISeriesService> { SeriesService(get(), get(), get(), get(), get(), get()) }
         single<IAccountService> { AccountService(get(), get(), get()) }
         single<IAuthService> {
             AuthService(

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -34,6 +34,13 @@ interface ISeriesService {
     fun getSeries(id: SeriesId): Series
 
     /**
+     * Re-evaluate whether a series is finished and close it if so. Run on every
+     * result write, whichever source it came from. No-op when the series is
+     * already complete or was deliberately reopened.
+     */
+    fun evaluateCompletion(id: SeriesId): Series
+
+    /**
      * Remove a series.
      *
      * @param SeriesId the target series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -7,6 +7,7 @@ import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.types.TeamId
 import com.lowbudgetlcs.equalsIgnoreOrder
@@ -14,17 +15,20 @@ import com.lowbudgetlcs.gateways.GatewayException
 import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
 import com.lowbudgetlcs.repositories.DatabaseException
 import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
 import com.lowbudgetlcs.repositories.series.ISeriesRepository
 import com.lowbudgetlcs.repositories.team.ITeamRepository
 import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Instant
 
 class SeriesService(
     private val codeRepo: ITournamentCodeRepository,
     private val seriesRepo: ISeriesRepository,
     private val eventRepo: IEventRepository,
     private val teamRepo: ITeamRepository,
+    private val gameRepo: IGameRepository,
     private val gate: IRiotTournamentGateway,
 ) : ISeriesService {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -52,6 +56,30 @@ class SeriesService(
     override fun getSeries(id: SeriesId): Series {
         logger.debug("Fetching series '$id'...")
         return seriesRepo.getById(id) ?: throw NoSuchElementException("Series not found")
+    }
+
+    override fun evaluateCompletion(id: SeriesId): Series {
+        val series = getSeries(id)
+        if (series.completed || series.reopenedAt != null) {
+            logger.debug("Series '$id' is not eligible for auto-close, skipping evaluation.")
+            return series
+        }
+        val wins =
+            gameRepo
+                .getBySeriesId(id)
+                .mapNotNull { it.result }
+                .groupingBy { it.winningTeamId }
+                .eachCount()
+        val leader = wins.maxByOrNull { it.value } ?: return series
+        // Wins, not games played: a 2-0 Bo3 is over after two games.
+        if (leader.value <= series.totalGames / 2) {
+            logger.debug("Series '$id' at ${leader.value} win(s) of ${series.totalGames}, still open.")
+            return series
+        }
+        val loser = series.participants.toList().firstOrNull { it != leader.key } ?: return series
+        logger.debug("Series '$id' won by '${leader.key}', closing.")
+        return seriesRepo.complete(id, Instant.now(), SeriesResult(leader.key, loser))
+            ?: throw DatabaseException("Failed to complete series with id '${id.value}'.")
     }
 
     override fun removeSeries(id: SeriesId) {

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/series/ISeriesRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/series/ISeriesRepository.kt
@@ -3,6 +3,7 @@ package com.lowbudgetlcs.repositories.series
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import java.time.Instant
 
@@ -18,6 +19,7 @@ interface ISeriesRepository {
     fun complete(
         id: SeriesId,
         completedAt: Instant,
+        result: SeriesResult? = null,
     ): Series?
 
     fun reopen(

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/series/SeriesRepository.kt
@@ -65,13 +65,29 @@ class SeriesRepository(
     override fun complete(
         id: SeriesId,
         completedAt: Instant,
+        result: SeriesResult?,
     ): Series? {
-        dsl
-            .update(SERIES)
-            .set(SERIES.COMPLETED, true)
-            .set(SERIES.COMPLETED_AT, completedAt)
-            .where(SERIES.ID.eq(id.value))
-            .execute()
+        dsl.transaction { t ->
+            val tx = t.dsl()
+            tx
+                .update(SERIES)
+                .set(SERIES.COMPLETED, true)
+                .set(SERIES.COMPLETED_AT, completedAt)
+                .where(SERIES.ID.eq(id.value))
+                .execute()
+            result?.let {
+                tx
+                    .insertInto(SERIES_RESULTS)
+                    .set(SERIES_RESULTS.SERIES_ID, id.value)
+                    .set(SERIES_RESULTS.WINNER_TEAM_ID, it.winningTeamId.value)
+                    .set(SERIES_RESULTS.LOSER_TEAM_ID, it.losingTeamId.value)
+                    .onConflict(SERIES_RESULTS.SERIES_ID)
+                    .doUpdate()
+                    .set(SERIES_RESULTS.WINNER_TEAM_ID, it.winningTeamId.value)
+                    .set(SERIES_RESULTS.LOSER_TEAM_ID, it.losingTeamId.value)
+                    .execute()
+            }
+        }
         return getById(id)
     }
 

--- a/src/test/kotlin/services/SeriesServiceTest.kt
+++ b/src/test/kotlin/services/SeriesServiceTest.kt
@@ -9,20 +9,26 @@ import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.event.models.types.EventStatus
 import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.filterByCompletion
 import com.lowbudgetlcs.domain.series.models.toSeriesId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.Team
 import com.lowbudgetlcs.domain.team.models.toTeamId
 import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.domain.team.models.types.TeamId
 import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
 import com.lowbudgetlcs.repositories.event.IEventRepository
-import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
 import com.lowbudgetlcs.repositories.series.ISeriesRepository
 import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -40,7 +46,8 @@ class SeriesServiceTest :
         val teamRepo = mockk<ITeamRepository>(relaxed = false)
         val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
         val tournamentGateway = mockk<IRiotTournamentGateway>(relaxed = false)
-        val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, tournamentGateway)
+        val gameRepo = mockk<IGameRepository>(relaxed = false)
+        val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, tournamentGateway)
 
         beforeTest { clearAllMocks() }
 
@@ -208,5 +215,140 @@ class SeriesServiceTest :
             bothSeries.filterByCompletion(
                 SeriesQuery(teamIds = null, eventStage = null, completed = false),
             ) shouldContainExactly listOf(openSeries)
+        }
+
+        fun seriesOf(
+            totalGames: Int,
+            completed: Boolean = false,
+            reopenedAt: Instant? = null,
+        ) = Series(
+            id = SeriesId(50),
+            eventId = EventId(1),
+            totalGames = totalGames,
+            participants = participatingTeams,
+            result = null,
+            eventStage = EventStage.PLAYOFFS,
+            completed = completed,
+            completedAt = null,
+            reopenedAt = reopenedAt,
+        )
+
+        fun gamesWon(winners: List<TeamId>) =
+            winners.mapIndexed { i, winner ->
+                Game(
+                    id = GameId(i + 1),
+                    seriesId = SeriesId(50),
+                    tournamentCodeId = null,
+                    riotMatchId = null,
+                    number = i + 1,
+                    createdAt = Instant.parse("2026-07-14T23:12:04Z"),
+                    result = GameResult(winner, if (winner == team1.id) team2.id else team1.id),
+                )
+            }
+
+        fun arrange(
+            series: Series,
+            winners: List<TeamId> = emptyList(),
+        ) {
+            every { seriesRepo.getById(series.id) } returns series
+            every { gameRepo.getBySeriesId(series.id) } returns gamesWon(winners)
+            every { seriesRepo.complete(series.id, any(), any()) } returns series.copy(completed = true)
+        }
+
+        "Bo3 closes at 2-0" {
+            val series = seriesOf(3)
+            arrange(series, listOf(team1.id, team1.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 1) {
+                seriesRepo.complete(series.id, any(), SeriesResult(team1.id, team2.id))
+            }
+        }
+
+        "Bo3 closes at 2-1" {
+            val series = seriesOf(3)
+            arrange(series, listOf(team1.id, team2.id, team1.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 1) {
+                seriesRepo.complete(series.id, any(), SeriesResult(team1.id, team2.id))
+            }
+        }
+
+        "Bo3 does not close at 1-1" {
+            val series = seriesOf(3)
+            arrange(series, listOf(team1.id, team2.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 0) { seriesRepo.complete(any(), any(), any()) }
+        }
+
+        "Bo5 closes at 3-0, 3-1 and 3-2 but not 2-2" {
+            listOf(
+                listOf(team1.id, team1.id, team1.id),
+                listOf(team1.id, team2.id, team1.id, team1.id),
+                listOf(team1.id, team2.id, team1.id, team2.id, team1.id),
+            ).forEach { winners ->
+                clearAllMocks()
+                val series = seriesOf(5)
+                arrange(series, winners)
+
+                service.evaluateCompletion(series.id)
+
+                verify(exactly = 1) {
+                    seriesRepo.complete(series.id, any(), SeriesResult(team1.id, team2.id))
+                }
+            }
+
+            clearAllMocks()
+            val drawn = seriesOf(5)
+            arrange(drawn, listOf(team1.id, team2.id, team1.id, team2.id))
+
+            service.evaluateCompletion(drawn.id)
+
+            verify(exactly = 0) { seriesRepo.complete(any(), any(), any()) }
+        }
+
+        "the winner recorded is the team with more wins" {
+            val series = seriesOf(3)
+            arrange(series, listOf(team2.id, team1.id, team2.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 1) {
+                seriesRepo.complete(series.id, any(), SeriesResult(team2.id, team1.id))
+            }
+        }
+
+        "a reopened series does not re-close when another result arrives" {
+            val series = seriesOf(3, reopenedAt = Instant.parse("2026-07-15T09:00:00Z"))
+            arrange(series, listOf(team1.id, team1.id, team1.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 0) { seriesRepo.complete(any(), any(), any()) }
+            verify(exactly = 0) { gameRepo.getBySeriesId(any()) }
+        }
+
+        "an already-completed series is not re-evaluated or double-written" {
+            val series = seriesOf(3, completed = true)
+            arrange(series, listOf(team1.id, team1.id))
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 0) { seriesRepo.complete(any(), any(), any()) }
+            verify(exactly = 0) { gameRepo.getBySeriesId(any()) }
+        }
+
+        "a series with no recorded results stays open" {
+            val series = seriesOf(3)
+            arrange(series)
+
+            service.evaluateCompletion(series.id)
+
+            verify(exactly = 0) { seriesRepo.complete(any(), any(), any()) }
         }
     })


### PR DESCRIPTION
Closes #196. Part of #189.

> **Fifth in stack #208.** Targets `dev/195-...`. Merge order: #206 → #207 → #209 → #210 → this.

## Why

#189's root cause is that **nothing ever completes a series** — `series_results` is never written, the callback is a stub, and Todd's End Series button makes no HTTP call. Completion has to be a side effect of results, not something a human remembers to do.

## The evaluation

`SeriesService.evaluateCompletion(seriesId)`:

```
wins = count of game results per team for the series
if max(wins) > totalGames / 2  ->  complete(series, winner)
```

Guarded on `completed = false AND reopened_at IS NULL`. Both guards short-circuit **before** reading games, so an ineligible series costs one lookup.

The predicate is **wins, not games played** — a 2-0 Bo3 is over after two games, a 3-1 Bo5 after four. Integer division gives the right threshold for every format: Bo3 → `wins > 1`, Bo5 → `wins > 2`, Bo1 → `wins > 0`.

Every source funnels through this one evaluation, which is what makes a series mixing coded and custom games close on the correct aggregate — the score is the sum of recorded results and no source is privileged.

```
callback   ─┐
Riot pull  ─┼─→ game_results ─→ evaluateCompletion ─→ series closed
self-serve ─┘
```

## `SeriesRepository.complete` now writes `series_results`

#192 added `complete(id, completedAt)`, which only flipped the flags — there was still no way to record who won. It now takes an optional `SeriesResult` and writes both in **one transaction**.

The parameter **defaults to null**, so the reopen path and #192's existing tests are untouched and this stays additive rather than rewriting an earlier PR in the stack.

The insert is an **upsert on `series_id`**. `series_results` has `series_id` as its primary key, so completing a series that was reopened after a previous completion would otherwise hit a PK violation rather than updating the recorded winner.

`SeriesService` gains `IGameRepository`, so `config/modules/Service.kt:28` and the unit test constructor are bumped.

## Verification

**142 tests across all suites, 0 failures.**

```
[pass] Bo3 closes at 2-0
[pass] Bo3 closes at 2-1
[pass] Bo3 does not close at 1-1
[pass] Bo5 closes at 3-0, 3-1 and 3-2 but not 2-2
[pass] the winner recorded is the team with more wins
[pass] a reopened series does not re-close when another result arrives
[pass] an already-completed series is not re-evaluated or double-written
[pass] a series with no recorded results stays open
```

- [x] Bo3 closes at 2-0 and at 2-1, but **not** at 1-1
- [x] Bo5 closes at 3-0, 3-1, 3-2, but not 2-2
- [x] The winner recorded is the team with more wins
- [x] A series with `reopened_at` set does **not** re-close when another result arrives
- [x] An already-completed series is not re-evaluated or double-written

### Both guards are mutation-tested

Green tests only prove the code passes; these prove the tests would catch the bug. Two deliberate mutations, each re-run:

| Mutation | Result |
|---|---|
| Drop the `reopenedAt != null` guard | `[FAIL] a reopened series does not re-close when another result arrives` |
| Change `leader.value <= totalGames / 2` to `<` | `[FAIL] Bo3 does not close at 1-1` and `[FAIL] Bo5 closes at 3-0, 3-1 and 3-2 but not 2-2` |

The reopened and already-completed tests also assert `gameRepo.getBySeriesId` is never called, so the short-circuit is verified rather than just its outcome.

### Lint

The two ktlint violations introduced in `SeriesServiceTest` were fixed **by hand**, not with `ktlintTestSourceSetFormat` — six other pre-existing files in that source set are also non-compliant and the formatter would have swept them all into this diff. Diff is 6 files. `detekt` passes.

## Not included

No route. This is internal logic consumed by the result-reporting endpoint (#198) and the callback (#202); nothing calls it yet.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
