### PR TITLE
feat: Tournament-V5 games-by-code gateway and result resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,4 +143,8 @@ dependencies {
     testImplementation(libs.bundles.kotest.unit)
     testImplementation(libs.reflect.core)
     testImplementation(libs.argon2.impl)
+    testImplementation(libs.bundles.ktor.client)
+    testImplementation(libs.bundles.ktor.client.plugins)
+    testImplementation(libs.ktor.serialization.json)
+    testImplementation(libs.ktor.client.mock)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 # ktor-client plugins
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 # jooq
 jooq-core = { group = "org.jooq", name = "jooq", version.ref = "jooq" }
 jooq-meta = { group = "org.jooq", name = "jooq-meta", version.ref = "jooq" }

--- a/src/main/kotlin/com/lowbudgetlcs/config/modules/HttpClient.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/config/modules/HttpClient.kt
@@ -3,17 +3,30 @@ package com.lowbudgetlcs.config.modules
 import com.lowbudgetlcs.serializers.InstantSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import org.koin.dsl.module
+import java.io.IOException
 import java.time.Instant
+
+const val MAX_RIOT_RETRIES = 3
 
 val httpClientModule =
     module {
         single {
             HttpClient(CIO) {
+                install(HttpRequestRetry) {
+                    maxRetries = MAX_RIOT_RETRIES
+                    retryIf { _, response ->
+                        response.status == HttpStatusCode.TooManyRequests || response.status.value >= 500
+                    }
+                    retryOnExceptionIf { _, cause -> cause is IOException }
+                    exponentialDelay()
+                }
                 install(ContentNegotiation) {
                     json(
                         Json {

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -4,6 +4,7 @@ import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.models.NewSeries
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 
@@ -39,6 +40,8 @@ interface ISeriesService {
      * already complete or was deliberately reopened.
      */
     fun evaluateCompletion(id: SeriesId): Series
+
+    suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome
 
     /**
      * Remove a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -1,17 +1,27 @@
 package com.lowbudgetlcs.domain.series
 
+import com.lowbudgetlcs.domain.account.models.types.Puuid
+import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
 import com.lowbudgetlcs.domain.event.models.toShortcode
 import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
+import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
 import com.lowbudgetlcs.domain.series.models.NewSeries
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.types.TeamId
 import com.lowbudgetlcs.equalsIgnoreOrder
 import com.lowbudgetlcs.gateways.GatewayException
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.RiotRegion
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGamesV5Dto
 import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
 import com.lowbudgetlcs.repositories.DatabaseException
 import com.lowbudgetlcs.repositories.event.IEventRepository
@@ -82,6 +92,93 @@ class SeriesService(
             ?: throw DatabaseException("Failed to complete series with id '${id.value}'.")
     }
 
+    override suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome {
+        val series = getSeries(id)
+        val recordedCodeIds = gameRepo.getBySeriesId(id).mapNotNull { it.tournamentCodeId }.toSet()
+        val outstanding = codeRepo.getBySeriesId(id).filter { it.id !in recordedCodeIds }
+        if (outstanding.isEmpty()) {
+            logger.debug("Series '$id' has no outstanding tournament codes.")
+            return RefreshOutcome.ANSWERED_EMPTY
+        }
+
+        var attributed = false
+        val unverified = mutableListOf<Shortcode>()
+        for (code in outstanding) {
+            val riotGames =
+                try {
+                    gate.getGames(code.shortcode)
+                } catch (e: RiotApiException) {
+                    logger.warn("Could not reach Riot for shortcode '${code.shortcode.value}': ${e.message}")
+                    unverified += code.shortcode
+                    continue
+                }
+            riotGames.forEach { riotGame ->
+                val result = resolveWinner(series, riotGame)
+                if (result != null) {
+                    gameRepo.insert(
+                        NewGame(
+                            seriesId = id,
+                            tournamentCodeId = code.id,
+                            riotMatchId = riotMatchIdOf(riotGame),
+                            result = result,
+                        ),
+                    )
+                    attributed = true
+                }
+            }
+        }
+
+        if (attributed) evaluateCompletion(id)
+        return when {
+            attributed -> RefreshOutcome.ATTRIBUTED
+            unverified.isNotEmpty() -> {
+                logger.warn(
+                    "Series '$id' could not be verified against Riot for codes " +
+                        unverified.joinToString { it.value },
+                )
+                RefreshOutcome.UNREACHABLE
+            }
+
+            else -> RefreshOutcome.ANSWERED_EMPTY
+        }
+    }
+
+    private fun seriesMetadata(id: SeriesId): String = """{"seriesId":${id.value}}"""
+
+    private fun riotMatchIdOf(riotGame: RiotTournamentGamesV5Dto): RiotMatchId? {
+        val platformId = RiotRegion.platformIdOf(riotGame.region)
+        if (platformId == null) {
+            logger.warn("Unknown Riot region '${riotGame.region}' on shortcode '${riotGame.shortCode}'.")
+            return null
+        }
+        return "${platformId}_${riotGame.gameId}".toRiotMatchId()
+    }
+
+    private fun resolveWinner(
+        series: Series,
+        riotGame: RiotTournamentGamesV5Dto,
+    ): GameResult? {
+        val puuids = riotGame.winningTeam.mapNotNull { runCatching { Puuid(it.puuid) }.getOrNull() }
+        val resolved = teamRepo.getTeamIdsByPuuids(puuids)
+        if (resolved.size < puuids.size) {
+            logger.warn(
+                "Series '${series.id}' shortcode '${riotGame.shortCode}': " +
+                    "${puuids.size - resolved.size} of ${puuids.size} winning puuids are unregistered.",
+            )
+        }
+        val counts = resolved.groupingBy { it }.eachCount()
+        val (first, second) = series.participants
+        val winner = listOf(first, second).maxByOrNull { counts[it] ?: 0 }
+        if (winner == null || (counts[winner] ?: 0) == 0) {
+            logger.warn(
+                "Series '${series.id}' shortcode '${riotGame.shortCode}': " +
+                    "no winning puuid resolved to either roster, leaving it for self-serve reporting.",
+            )
+            return null
+        }
+        return GameResult(winner, if (winner == first) second else first)
+    }
+
     override fun removeSeries(id: SeriesId) {
         logger.debug("Deleting series '$id'...")
         try {
@@ -106,12 +203,17 @@ class SeriesService(
         ) {
             "Provided teams are not part of series with id ${series.id.value}."
         }
+        try {
+            refreshFromRiot(series.id)
+        } catch (e: Throwable) {
+            logger.warn("Could not refresh series '${series.id}' from Riot before issuing a code: ${e.message}")
+        }
         logger.debug("Fetching tournament id for event '${series.eventId}'...t add")
         val event =
             eventRepo.getById(series.eventId)
                 ?: throw DatabaseException("Series with id '${series.id}' does not have parent event.")
         val response =
-            gate.getCode(event.riotTournamentId, ShortcodeOptions())
+            gate.getCode(event.riotTournamentId, ShortcodeOptions(metadata = seriesMetadata(series.id)))
                 ?: throw GatewayException("Failed to create tournament code.")
         val shortcode = response.codes.first()
         return codeRepo.insert(newCode, shortcode.toShortcode()) ?: throw DatabaseException("Failed to save game.")

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/RefreshOutcome.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/RefreshOutcome.kt
@@ -1,0 +1,7 @@
+package com.lowbudgetlcs.domain.series.models
+
+enum class RefreshOutcome {
+    ATTRIBUTED,
+    ANSWERED_EMPTY,
+    UNREACHABLE,
+}

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/IRiotTournamentGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/IRiotTournamentGateway.kt
@@ -1,6 +1,7 @@
 package com.lowbudgetlcs.gateways.riot.tournament
 
 import com.lowbudgetlcs.domain.event.models.RiotTournament
+import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
 import com.lowbudgetlcs.domain.event.models.types.EventName
 import com.lowbudgetlcs.domain.event.models.types.RiotTournamentId
@@ -12,4 +13,6 @@ interface IRiotTournamentGateway {
         riotTournamentId: RiotTournamentId,
         options: ShortcodeOptions,
     ): RiotShortcodeDto?
+
+    suspend fun getGames(shortcode: Shortcode): List<RiotTournamentGamesV5Dto>
 }

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotRegion.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotRegion.kt
@@ -1,0 +1,24 @@
+package com.lowbudgetlcs.gateways.riot.tournament
+
+enum class RiotRegion(
+    val platformId: String,
+) {
+    BR("BR1"),
+    EUNE("EUN1"),
+    EUW("EUW1"),
+    JP("JP1"),
+    LAN("LA1"),
+    LAS("LA2"),
+    NA("NA1"),
+    OCE("OC1"),
+    PBE("PBE1"),
+    RU("RU"),
+    TR("TR1"),
+    KR("KR"),
+    ;
+
+    companion object {
+        fun platformIdOf(region: String): String? =
+            entries.firstOrNull { it.name.equals(region, ignoreCase = true) }?.platformId
+    }
+}

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGamesDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGamesDto.kt
@@ -1,0 +1,23 @@
+package com.lowbudgetlcs.gateways.riot.tournament
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RiotTournamentTeamV5Dto(
+    val puuid: String = "",
+)
+
+@Serializable
+data class RiotTournamentGamesV5Dto(
+    val startTime: Long = 0,
+    val winningTeam: List<RiotTournamentTeamV5Dto> = emptyList(),
+    val losingTeam: List<RiotTournamentTeamV5Dto> = emptyList(),
+    val shortCode: String = "",
+    val metaData: String = "",
+    val gameId: Long = 0,
+    val gameName: String = "",
+    val gameType: String = "",
+    val gameMap: Int = -1,
+    val gameMode: String = "",
+    val region: String = "",
+)

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
@@ -1,6 +1,7 @@
 package com.lowbudgetlcs.gateways.riot.tournament
 
 import com.lowbudgetlcs.domain.event.models.RiotTournament
+import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
 import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
 import com.lowbudgetlcs.domain.event.models.types.EventName
@@ -8,6 +9,7 @@ import com.lowbudgetlcs.domain.event.models.types.RiotTournamentId
 import com.lowbudgetlcs.gateways.riot.RiotApiException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -82,6 +84,21 @@ class RiotTournamentGateway(
                 logger.warn("Failed to create codes.")
                 throw RiotApiException("Unexpected Riot API error: ${res.status}")
             }
+        }
+    }
+
+    override suspend fun getGames(shortcode: Shortcode): List<RiotTournamentGamesV5Dto> {
+        logger.debug("Fetching games for shortcode '${shortcode.value}'...")
+        val res: HttpResponse =
+            client.get("$url/games/by-code/${shortcode.value}") {
+                headers {
+                    append("X-Riot-Token", apiKey)
+                }
+            }
+        return when (res.status) {
+            HttpStatusCode.OK -> res.body<List<RiotTournamentGamesV5Dto>>()
+            HttpStatusCode.NotFound -> emptyList()
+            else -> throw RiotApiException("Unexpected Riot API error: ${res.status}")
         }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/team/ITeamRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/team/ITeamRepository.kt
@@ -1,5 +1,6 @@
 package com.lowbudgetlcs.repositories.team
 
+import com.lowbudgetlcs.domain.account.models.types.Puuid
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
@@ -23,6 +24,8 @@ interface ITeamRepository {
     fun getBySeriesId(seriesId: SeriesId): List<Team>
 
     fun getByName(name: TeamName): List<Team>
+
+    fun getTeamIdsByPuuids(puuids: List<Puuid>): List<TeamId>
 
     fun update(
         team: Team,

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/team/TeamRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/team/TeamRepository.kt
@@ -1,6 +1,7 @@
 package com.lowbudgetlcs.repositories.team
 
 import com.lowbudgetlcs.domain.event.models.toEventId
+import com.lowbudgetlcs.domain.account.models.types.Puuid
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
@@ -15,6 +16,7 @@ import com.lowbudgetlcs.domain.team.models.types.TeamName
 import org.jooq.DSLContext
 import org.jooq.Record
 import org.jooq.storage.tables.references.PLAYERS_TO_TEAM
+import org.jooq.storage.tables.references.RIOT_ACCOUNTS
 import org.jooq.storage.tables.references.TEAMS
 import org.jooq.storage.tables.references.TEAM_TO_SERIES
 
@@ -36,6 +38,18 @@ class TeamRepository(
         dsl.select(TEAMS.ID, TEAMS.NAME, TEAMS.LOGO, TEAMS.EVENT_ID)
             .from(TEAMS.innerJoin(TEAM_TO_SERIES).on(TEAMS.ID.eq(TEAM_TO_SERIES.TEAM_ID)))
             .where(TEAM_TO_SERIES.SERIES_ID.eq(seriesId.value)).fetch().mapNotNull(::rowToTeam)
+
+    override fun getTeamIdsByPuuids(puuids: List<Puuid>): List<TeamId> {
+        if (puuids.isEmpty()) return emptyList()
+        return dsl
+            .select(PLAYERS_TO_TEAM.TEAM_ID)
+            .from(RIOT_ACCOUNTS)
+            .innerJoin(PLAYERS_TO_TEAM)
+            .on(RIOT_ACCOUNTS.PLAYER_ID.eq(PLAYERS_TO_TEAM.PLAYER_ID))
+            .where(RIOT_ACCOUNTS.RIOT_PUUID.`in`(puuids.map { it.value }))
+            .fetch()
+            .mapNotNull { it[PLAYERS_TO_TEAM.TEAM_ID]?.toTeamId() }
+    }
 
     override fun getByName(name: TeamName): List<Team> =
         selectTeams().where(TEAMS.NAME.eq(name.value)).fetch().mapNotNull(::rowToTeam)

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/ITournamentCodeRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/ITournamentCodeRepository.kt
@@ -4,9 +4,12 @@ import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
 
 interface ITournamentCodeRepository {
     fun getById(id: TournamentCodeId): TournamentCode?
+
+    fun getBySeriesId(id: SeriesId): List<TournamentCode>
 
     fun insert(
         newCode: NewTournamentCode,

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/TournamentCodeRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/TournamentCodeRepository.kt
@@ -7,6 +7,7 @@ import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.game.models.toTournamentCodeId
 import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 import com.lowbudgetlcs.domain.series.models.toSeriesId
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.toTeamId
 import org.jooq.DSLContext
 import org.jooq.Record
@@ -17,6 +18,13 @@ class TournamentCodeRepository(
 ) : ITournamentCodeRepository {
     override fun getById(id: TournamentCodeId) =
         selectCodes().where(TOURNAMENT_CODES.ID.eq(id.value)).fetchOne()?.let(::rowToTournamentCode)
+
+    override fun getBySeriesId(id: SeriesId): List<TournamentCode> =
+        selectCodes()
+            .where(TOURNAMENT_CODES.SERIES_ID.eq(id.value))
+            .orderBy(TOURNAMENT_CODES.ID)
+            .fetch()
+            .mapNotNull(::rowToTournamentCode)
 
     override fun insert(
         newCode: NewTournamentCode,

--- a/src/test/kotlin/gateways/RiotTournamentGatewayTest.kt
+++ b/src/test/kotlin/gateways/RiotTournamentGatewayTest.kt
@@ -1,0 +1,125 @@
+package gateways
+
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.RiotRegion
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGateway
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+private const val WINNER_PUUID_1 = "w1-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+private const val WINNER_PUUID_2 = "w2-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+private val GAMES_BY_CODE_PAYLOAD =
+    """
+    [
+      {
+        "startTime": 1752537124000,
+        "winningTeam": [ { "puuid": "$WINNER_PUUID_1" }, { "puuid": "$WINNER_PUUID_2" } ],
+        "losingTeam": [ { "puuid": "$WINNER_PUUID_1" } ],
+        "shortCode": "NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae",
+        "metaData": "{\"seriesId\":42}",
+        "gameId": 5102531894,
+        "gameName": "test-game",
+        "gameType": "TOURNAMENT",
+        "gameMap": 11,
+        "gameMode": "CLASSIC",
+        "region": "NA"
+      }
+    ]
+    """.trimIndent()
+
+private fun gatewayOf(engine: MockEngine) =
+    RiotTournamentGateway(
+        client =
+            HttpClient(engine) {
+                install(HttpRequestRetry) {
+                    maxRetries = 3
+                    retryIf { _, response -> response.status == HttpStatusCode.TooManyRequests }
+                    delayMillis { 0 }
+                }
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            },
+        apiKey = "test-key",
+        useStubs = false,
+        providerId = 1,
+    )
+
+class RiotTournamentGatewayTest :
+    StringSpec({
+        val shortcode = Shortcode("NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae")
+
+        "getGames parses a realistic games-by-code payload" {
+            val gateway =
+                gatewayOf(
+                    MockEngine {
+                        respond(
+                            GAMES_BY_CODE_PAYLOAD,
+                            HttpStatusCode.OK,
+                            headersOf("Content-Type", ContentType.Application.Json.toString()),
+                        )
+                    },
+                )
+
+            val games = gateway.getGames(shortcode)
+
+            games.size shouldBe 1
+            games.first().gameId shouldBe 5102531894L
+            games.first().region shouldBe "NA"
+            games.first().winningTeam.map { it.puuid } shouldBe listOf(WINNER_PUUID_1, WINNER_PUUID_2)
+        }
+
+        "getGames treats 404 as Riot answering with no game" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.NotFound) })
+
+            gateway.getGames(shortcode).shouldBeEmpty()
+        }
+
+        "getGames throws rather than reporting empty when Riot is unreachable" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.ServiceUnavailable) })
+
+            shouldThrow<RiotApiException> { gateway.getGames(shortcode) }
+        }
+
+        "a 429 is retried rather than failing outright" {
+            var calls = 0
+            val gateway =
+                gatewayOf(
+                    MockEngine {
+                        calls++
+                        if (calls < 3) {
+                            respondError(HttpStatusCode.TooManyRequests)
+                        } else {
+                            respond(
+                                GAMES_BY_CODE_PAYLOAD,
+                                HttpStatusCode.OK,
+                                headersOf("Content-Type", ContentType.Application.Json.toString()),
+                            )
+                        }
+                    },
+                )
+
+            gateway.getGames(shortcode).size shouldBe 1
+            calls shouldBe 3
+        }
+
+        "the tournament region enum maps to a platformId" {
+            RiotRegion.platformIdOf("NA") shouldBe "NA1"
+            RiotRegion.platformIdOf("EUW") shouldBe "EUW1"
+            RiotRegion.platformIdOf("KR") shouldBe "KR"
+            RiotRegion.platformIdOf("NOT_A_REGION") shouldBe null
+        }
+    })

--- a/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
+++ b/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
@@ -1,0 +1,214 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGamesV5Dto
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentTeamV5Dto
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+
+private val TEAM_1 = TeamId(1)
+private val TEAM_2 = TeamId(2)
+private val SERIES_ID = SeriesId(50)
+
+private const val PUUID_A = "aa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+private const val PUUID_B = "bb-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+private const val PUUID_C = "cc-ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+private class Fixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    val series =
+        Series(
+            id = SERIES_ID,
+            eventId = EventId(1),
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 3,
+            participants = Pair(TEAM_1, TEAM_2),
+            result = null,
+            completed = false,
+            completedAt = null,
+            reopenedAt = null,
+        )
+
+    fun code(
+        id: Int,
+        shortcode: String,
+    ) = TournamentCode(
+        id = TournamentCodeId(id),
+        shortcode = Shortcode(shortcode),
+        blueTeamId = TEAM_1,
+        redTeamId = TEAM_2,
+        seriesId = SERIES_ID,
+        createdAt = Instant.parse("2026-07-14T22:58:31Z"),
+    )
+
+    fun riotGame(
+        winners: List<String>,
+        region: String = "NA",
+        shortCode: String = "SHORT-A",
+    ) = RiotTournamentGamesV5Dto(
+        winningTeam = winners.map { RiotTournamentTeamV5Dto(it) },
+        shortCode = shortCode,
+        gameId = 5102531894L,
+        region = region,
+    )
+
+    fun playedGame(codeId: Int) =
+        Game(
+            id = GameId(1),
+            seriesId = SERIES_ID,
+            tournamentCodeId = TournamentCodeId(codeId),
+            riotMatchId = null,
+            number = 1,
+            createdAt = Instant.parse("2026-07-14T23:12:04Z"),
+            result = null,
+        )
+
+    fun withSeries(
+        codes: List<TournamentCode>,
+        recorded: List<Game> = emptyList(),
+    ) {
+        every { seriesRepo.getById(SERIES_ID) } returns series
+        every { gameRepo.getBySeriesId(SERIES_ID) } returns recorded
+        every { codeRepo.getBySeriesId(SERIES_ID) } returns codes
+        every { gameRepo.insert(any()) } returns null
+        every { seriesRepo.complete(any(), any(), any()) } returns series
+    }
+}
+
+class SeriesRefreshFromRiotTest :
+    StringSpec({
+        "attributes a game Riot has and reports ATTRIBUTED" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(Shortcode("SHORT-A")) } returns
+                listOf(f.riotGame(listOf(PUUID_A, PUUID_B)))
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1, TEAM_1)
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) {
+                f.gameRepo.insert(
+                    NewGame(
+                        seriesId = SERIES_ID,
+                        tournamentCodeId = TournamentCodeId(1),
+                        riotMatchId = "NA1_5102531894".toRiotMatchId(),
+                        result = GameResult(TEAM_1, TEAM_2),
+                    ),
+                )
+            }
+        }
+
+        "reports ANSWERED_EMPTY when Riot has no game" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "reports UNREACHABLE distinctly from ANSWERED_EMPTY" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } throws RiotApiException("503")
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.UNREACHABLE
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "attributes to the older code when the game was played on it" {
+            val f = Fixture()
+            val older = f.code(1, "SHORT-OLDER")
+            val newer = f.code(2, "SHORT-NEWER")
+            coEvery { f.gateway.getGames(older.shortcode) } returns
+                listOf(f.riotGame(listOf(PUUID_A), shortCode = "SHORT-OLDER"))
+            coEvery { f.gateway.getGames(newer.shortcode) } returns emptyList()
+            f.withSeries(listOf(older, newer))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) { f.gameRepo.insert(match { it.tournamentCodeId == TournamentCodeId(1) }) }
+            verify(exactly = 0) { f.gameRepo.insert(match { it.tournamentCodeId == TournamentCodeId(2) }) }
+        }
+
+        "skips codes that already have a game" {
+            val f = Fixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")), recorded = listOf(f.playedGame(1)))
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "a winning roster with unregistered puuids still resolves via overlap" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } returns
+                listOf(f.riotGame(listOf(PUUID_A, PUUID_B, PUUID_C)))
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_2, TEAM_2)
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) { f.gameRepo.insert(match { it.result == GameResult(TEAM_2, TEAM_1) }) }
+        }
+
+        "an all-unknown winning roster records nothing" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } returns listOf(f.riotGame(listOf(PUUID_A)))
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns emptyList()
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "an unknown region leaves riotMatchId null rather than failing" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } returns
+                listOf(f.riotGame(listOf(PUUID_A), region = "NOPE"))
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) { f.gameRepo.insert(match { it.riotMatchId == null }) }
+        }
+    })

--- a/src/test/kotlin/services/SeriesServiceTest.kt
+++ b/src/test/kotlin/services/SeriesServiceTest.kt
@@ -45,9 +45,9 @@ class SeriesServiceTest :
         val eventRepo = mockk<IEventRepository>(relaxed = false)
         val teamRepo = mockk<ITeamRepository>(relaxed = false)
         val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
-        val tournamentGateway = mockk<IRiotTournamentGateway>(relaxed = false)
+        val gameGateway = mockk<IRiotTournamentGateway>(relaxed = false)
         val gameRepo = mockk<IGameRepository>(relaxed = false)
-        val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, tournamentGateway)
+        val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gameGateway)
 
         beforeTest { clearAllMocks() }
 
@@ -250,8 +250,8 @@ class SeriesServiceTest :
             series: Series,
             winners: List<TeamId> = emptyList(),
         ) {
-            every { seriesRepo.getById(series.id) } returns series
-            every { gameRepo.getBySeriesId(series.id) } returns gamesWon(winners)
+            every { seriesRepo.getById(any()) } returns series
+            every { gameRepo.getBySeriesId(any()) } returns gamesWon(winners)
             every { seriesRepo.complete(series.id, any(), any()) } returns series.copy(completed = true)
         }
 


### PR DESCRIPTION
Closes #197. Part of #189.

> **Sixth in stack #208.** Targets `dev/196-...`. Merge order: #206 → #207 → #209 → #210 → #211 → this.

## Why

The failure mode behind #189 is closure depending on people remembering. It turns out we do not have to depend on them: **a coded game is always retrievable from Riot on demand.** The callback is only a notification — Riot's record is what *triggers* it, so if `relay` was down the attempt failed but the record is still there to pull.

## Gateway

`getGames(shortcode)` on `IRiotTournamentGateway`, hitting `GET /lol/tournament/v5/games/by-code/{code}` — same host, same key as the existing `getCode`, so this is one new method rather than a Match-V5 integration.

**404 and failure are deliberately different.** A 404 means Riot was reached and has no game for that code, and returns an empty list. Anything else throws `RiotApiException`. Conflating them would erase the distinction the whole ticket rests on.

New DTOs `RiotTournamentGamesV5Dto` / `RiotTournamentTeamV5Dto`. I put them in `gateways/riot/tournament/` next to `RiotShortcodeDto` rather than `api/dto/riot/` as the ticket suggested — that package holds the inbound callback body (`PostMatchDto`), and these are a gateway response. Happy to move them if you prefer the ticket's placement.

## `refreshFromRiot(seriesId)`

For each `tournament_codes` row with no `games` row, ask Riot. On a hit, create the game and its result, then run the #196 completion check. Returns three distinguishable outcomes:

| Outcome | Meaning |
|---|---|
| `ATTRIBUTED` | Riot named a code and a winner; already recorded |
| `ANSWERED_EMPTY` | Riot reached, no game on any outstanding code |
| `UNREACHABLE` | 429 / 5xx / timeout, logged at WARN naming the unverified codes |

This is what lets #198 never guess a code.

## Winner resolution

`puuid → riot_accounts.riot_puuid → player_id → players_to_team → teams`, added as `getTeamIdsByPuuids` on `ITeamRepository`. Whichever of the series' two rosters overlaps most wins.

Unregistered puuids are simply absent from the result, so a roster with subs or ringers still resolves by overlap. If **nothing** resolves, the game is not recorded and a WARN names the series and shortcode, leaving it for self-serve.

## Trigger 1 and `metaData`

`createGame` now refreshes before issuing, so numbering self-heals at the moment it matters. The call is wrapped so **a Riot failure cannot block issuance** — players are never blocked.

`ShortcodeOptions.metadata` was always `""`. Codes now carry `{"seriesId":N}`, which Riot echoes back on both the callback and `games/by-code`. The code id is not available before the insert, so only the series is stamped.

## Rate limiting

`HttpRequestRetry` on the Ktor client — retry on 429 and 5xx with exponential backoff, plus IO exceptions. This has been absent since `RateLimiter.kt` was deleted in `e942ebe`.

## Region mapping

`games/by-code` returns the tournament enum (`NA`) while a match id needs a platformId (`NA1`), so `RiotRegion` maps between them. An unmappable region records the game with a **null** `riot_match_id` rather than failing — the result still counts toward completion, which is what matters.

## Verification

**155 tests across all suites, 0 failures.**

`RiotTournamentGatewayTest` drives the real gateway through Ktor's `MockEngine`:

```
[pass] getGames parses a realistic games-by-code payload
[pass] getGames treats 404 as Riot answering with no game
[pass] getGames throws rather than reporting empty when Riot is unreachable
[pass] a 429 is retried rather than failing outright
[pass] the tournament region enum maps to a platformId
```

`SeriesRefreshFromRiotTest`:

```
[pass] attributes a game Riot has and reports ATTRIBUTED
[pass] reports ANSWERED_EMPTY when Riot has no game
[pass] reports UNREACHABLE distinctly from ANSWERED_EMPTY
[pass] attributes to the older code when the game was played on it
[pass] skips codes that already have a game
[pass] a winning roster with unregistered puuids still resolves via overlap
[pass] an all-unknown winning roster records nothing
[pass] an unknown region leaves riotMatchId null rather than failing
```

- [x] Unit test with a stubbed client resolves the winning `teamId` from a realistic payload
- [x] A winning roster with unregistered puuids **still** resolves via overlap
- [x] An all-unknown roster records nothing and logs at WARN with series + shortcode
- [x] A 429 backs off and retries rather than failing outright
- [x] `refreshFromRiot` returns distinguishable outcomes for attributed / answered-empty / unreachable
- [x] Two outstanding codes with the game played on the **older** one → attributed to that code
- [x] `metaData` on a newly issued code carries the series identity

The Riot-outage-during-`createGame` case is covered by the `try`/`catch` around trigger 1; it is asserted indirectly rather than by a dedicated test, since `createGame` needs the full gateway stubbed.

### Note on the new test spec

The refresh tests live in their own `SeriesRefreshFromRiotTest` rather than in `SeriesServiceTest`. Two MockK behaviours forced this and are worth knowing before writing more suspend-heavy tests:

1. **`coEvery` after `every` discards the earlier stubs.** Every suspend stub must be registered *before* the non-suspend ones or they silently vanish.
2. The spec-level shared mocks in `SeriesServiceTest` leaked recorded calls between these tests even with `clearAllMocks()`. A per-test `Fixture` building fresh mocks fixes it.

## Known gap

⚠️ `tournament-stub/v5` has **no** `games/by-code` — only real `tournament-v5` does, and `RiotTournamentGateway.kt` picks the host from `riot.useStubs`. Local development cannot exercise the pull path against the stub host. The `MockEngine` tests cover the gateway contract, but an end-to-end local run still needs a test double.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
