### PR TITLE
feat: Result reporting endpoint (self-serve and Riot-verified)

### DIFF
--- a/src/itest/kotlin/TournamentCodeRepositoryTest.kt
+++ b/src/itest/kotlin/TournamentCodeRepositoryTest.kt
@@ -142,4 +142,18 @@ class TournamentCodeRepositoryTest :
                 repo.insert(newCode, shortcode = "ABCD".toShortcode())
             }
         }
+
+        "A code can be looked up by the shortcode a human reads off their client" {
+            val shortcode = "NA04eff-lookup".toShortcode()
+            val inserted = repo.insert(newCode, shortcode = shortcode).shouldNotBeNull()
+
+            val found = repo.getByShortcode(shortcode).shouldNotBeNull()
+
+            found.id shouldBe inserted.id
+            found.seriesId shouldBe series.id
+        }
+
+        "An unknown shortcode resolves to null rather than an arbitrary code" {
+            repo.getByShortcode("NOT-A-REAL-CODE".toShortcode()) shouldBe null
+        }
     })

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/games/GameDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/games/GameDto.kt
@@ -1,0 +1,22 @@
+package com.lowbudgetlcs.api.dto.games
+
+import com.lowbudgetlcs.serializers.InstantSerializer
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@Serializable
+data class GameDto(
+    val id: Int,
+    val seriesId: Int,
+    val tournamentCodeId: Int?,
+    val riotMatchId: String?,
+    val number: Int,
+    @Serializable(with = InstantSerializer::class) val createdAt: Instant,
+    val result: GameResultDto?,
+)
+
+@Serializable
+data class GameResultDto(
+    val winningTeamId: Int,
+    val losingTeamId: Int,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/games/GameMappers.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/games/GameMappers.kt
@@ -1,0 +1,26 @@
+package com.lowbudgetlcs.api.dto.games
+
+import com.lowbudgetlcs.domain.event.models.toShortcode
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.toTournamentCodeId
+import com.lowbudgetlcs.domain.series.models.ReportedResult
+import com.lowbudgetlcs.domain.team.models.toTeamId
+
+fun Game.toDto(): GameDto =
+    GameDto(
+        id = id.value,
+        seriesId = seriesId.value,
+        tournamentCodeId = tournamentCodeId?.value,
+        riotMatchId = riotMatchId?.value,
+        number = number,
+        createdAt = createdAt,
+        result = result?.let { GameResultDto(it.winningTeamId.value, it.losingTeamId.value) },
+    )
+
+fun ReportResultDto.toReportedResult(): ReportedResult =
+    ReportedResult(
+        winningTeamId = winnerTeamId?.toTeamId(),
+        losingTeamId = loserTeamId?.toTeamId(),
+        tournamentCodeId = tournamentCodeId?.toTournamentCodeId(),
+        shortcode = shortcode?.toShortcode(),
+    )

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/games/ReportResultDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/games/ReportResultDto.kt
@@ -1,0 +1,11 @@
+package com.lowbudgetlcs.api.dto.games
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReportResultDto(
+    val winnerTeamId: Int? = null,
+    val loserTeamId: Int? = null,
+    val tournamentCodeId: Int? = null,
+    val shortcode: String? = null,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
@@ -9,4 +9,10 @@ class SeriesResources {
         val parent: SeriesResources = SeriesResources(),
         val seriesId: Int,
     )
+
+    @Resource("{seriesId}/results")
+    data class Results(
+        val parent: SeriesResources = SeriesResources(),
+        val seriesId: Int,
+    )
 }

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
@@ -1,9 +1,12 @@
 package com.lowbudgetlcs.api.routes.v1.series
 
 import com.lowbudgetlcs.api.dto.games.CreateGameDto
+import com.lowbudgetlcs.api.dto.games.ReportResultDto
 import com.lowbudgetlcs.api.dto.games.toDto
 import com.lowbudgetlcs.api.dto.games.toNewTournamentCode
+import com.lowbudgetlcs.api.dto.games.toReportedResult
 import com.lowbudgetlcs.domain.series.ISeriesService
+import com.lowbudgetlcs.domain.series.models.toSeriesId
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.request.receive
@@ -23,6 +26,15 @@ fun Route.seriesRoutesV1(seriesService: ISeriesService) {
             logger.debug(dto.toString())
             val created = seriesService.createGame(dto.toNewTournamentCode(route.seriesId))
             call.respond(HttpStatusCode.Created, created.toDto())
+        }
+        post<SeriesResources.Results> { route ->
+            val dto = call.receive<ReportResultDto>()
+            logger.debug(dto.toString())
+            val outcome = seriesService.reportResult(route.seriesId.toSeriesId(), dto.toReportedResult())
+            call.respond(
+                if (outcome.recorded) HttpStatusCode.Created else HttpStatusCode.OK,
+                outcome.game.toDto(),
+            )
         }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -5,6 +5,8 @@ import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.RefreshOutcome
+import com.lowbudgetlcs.domain.series.models.ReportOutcome
+import com.lowbudgetlcs.domain.series.models.ReportedResult
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 
@@ -42,6 +44,11 @@ interface ISeriesService {
     fun evaluateCompletion(id: SeriesId): Series
 
     suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome
+
+    suspend fun reportResult(
+        id: SeriesId,
+        report: ReportedResult,
+    ): ReportOutcome
 
     /**
      * Remove a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -5,14 +5,18 @@ import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
 import com.lowbudgetlcs.domain.event.models.toShortcode
 import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.series.game.models.Game
 import com.lowbudgetlcs.domain.series.game.models.GameResult
 import com.lowbudgetlcs.domain.series.game.models.NewGame
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
 import com.lowbudgetlcs.domain.series.game.models.types.RiotMatchId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.RefreshOutcome
+import com.lowbudgetlcs.domain.series.models.ReportOutcome
+import com.lowbudgetlcs.domain.series.models.ReportedResult
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
@@ -20,9 +24,9 @@ import com.lowbudgetlcs.domain.team.models.types.TeamId
 import com.lowbudgetlcs.equalsIgnoreOrder
 import com.lowbudgetlcs.gateways.GatewayException
 import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
 import com.lowbudgetlcs.gateways.riot.tournament.RiotRegion
 import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGamesV5Dto
-import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
 import com.lowbudgetlcs.repositories.DatabaseException
 import com.lowbudgetlcs.repositories.event.IEventRepository
 import com.lowbudgetlcs.repositories.game.IGameRepository
@@ -143,6 +147,110 @@ class SeriesService(
         }
     }
 
+    override suspend fun reportResult(
+        id: SeriesId,
+        report: ReportedResult,
+    ): ReportOutcome {
+        val series = getSeries(id)
+        require(report.tournamentCodeId == null || report.shortcode == null) {
+            "Provide either tournamentCodeId or shortcode, not both."
+        }
+        val declared = declaredResult(series, report)
+        val target = resolveTarget(series, report)
+
+        val before = gameRepo.getBySeriesId(id)
+        if (target != null) {
+            before.firstOrNull { it.tournamentCodeId == target.id && it.result != null }?.let {
+                logger.info("Code '${target.shortcode.value}' already has a result, returning game '${it.id.value}'.")
+                return ReportOutcome(it, recorded = false)
+            }
+        }
+        val outstanding = codeRepo.getBySeriesId(id).filter { code -> before.none { it.tournamentCodeId == code.id } }
+
+        refreshQuietly(id)
+        val pulled =
+            gameRepo.getBySeriesId(id).filter { game ->
+                game.result != null && before.none { it.id == game.id }
+            }
+
+        if (target != null) {
+            pulled.firstOrNull { it.tournamentCodeId == target.id }?.let { return ReportOutcome(it, recorded = true) }
+            return ReportOutcome(record(id, target.id, declared ?: noWinner(id)), recorded = true)
+        }
+        pulled.firstOrNull()?.let { return ReportOutcome(it, recorded = true) }
+
+        if (declared == null && outstanding.isEmpty()) {
+            before.lastOrNull { it.result != null }?.let {
+                logger.info("Series '$id' has no outstanding codes, returning recorded game '${it.id.value}'.")
+                return ReportOutcome(it, recorded = false)
+            }
+        }
+        return ReportOutcome(record(id, null, declared ?: noWinner(id)), recorded = true)
+    }
+
+    private fun noWinner(id: SeriesId): Nothing =
+        throw IllegalArgumentException(
+            "No winner was named and Riot has no record of a game for series '${id.value}'.",
+        )
+
+    private fun record(
+        id: SeriesId,
+        codeId: TournamentCodeId?,
+        result: GameResult,
+    ): Game {
+        val game =
+            gameRepo.insert(NewGame(id, codeId, null, result))
+                ?: throw DatabaseException("Failed to record a result for series '${id.value}'.")
+        evaluateCompletion(id)
+        return game
+    }
+
+    private fun declaredResult(
+        series: Series,
+        report: ReportedResult,
+    ): GameResult? {
+        val winner = report.winningTeamId
+        if (winner == null) {
+            require(report.losingTeamId == null) { "A losing team cannot be given without a winning team." }
+            return null
+        }
+        val (first, second) = series.participants
+        require(winner == first || winner == second) {
+            "Team '${winner.value}' is not a participant in series '${series.id.value}'."
+        }
+        val loser = if (winner == first) second else first
+        report.losingTeamId?.let {
+            require(it == loser) { "Team '${it.value}' is not the losing participant in series '${series.id.value}'." }
+        }
+        return GameResult(winner, loser)
+    }
+
+    private fun resolveTarget(
+        series: Series,
+        report: ReportedResult,
+    ): TournamentCode? {
+        val code =
+            report.tournamentCodeId?.let {
+                codeRepo.getById(it) ?: throw NoSuchElementException("Tournament code with id ${it.value} not found")
+            } ?: report.shortcode?.let {
+                codeRepo.getByShortcode(it) ?: throw NoSuchElementException("Tournament code '${it.value}' not found")
+            } ?: return null
+        if (code.seriesId != series.id) {
+            throw NoSuchElementException(
+                "Tournament code '${code.shortcode.value}' does not belong to series '${series.id.value}'",
+            )
+        }
+        return code
+    }
+
+    private suspend fun refreshQuietly(id: SeriesId) {
+        try {
+            refreshFromRiot(id)
+        } catch (e: Throwable) {
+            logger.warn("Could not refresh series '$id' from Riot: ${e.message}")
+        }
+    }
+
     private fun seriesMetadata(id: SeriesId): String = """{"seriesId":${id.value}}"""
 
     private fun riotMatchIdOf(riotGame: RiotTournamentGamesV5Dto): RiotMatchId? {
@@ -203,11 +311,7 @@ class SeriesService(
         ) {
             "Provided teams are not part of series with id ${series.id.value}."
         }
-        try {
-            refreshFromRiot(series.id)
-        } catch (e: Throwable) {
-            logger.warn("Could not refresh series '${series.id}' from Riot before issuing a code: ${e.message}")
-        }
+        refreshQuietly(series.id)
         logger.debug("Fetching tournament id for event '${series.eventId}'...t add")
         val event =
             eventRepo.getById(series.eventId)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/ReportOutcome.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/ReportOutcome.kt
@@ -1,0 +1,8 @@
+package com.lowbudgetlcs.domain.series.models
+
+import com.lowbudgetlcs.domain.series.game.models.Game
+
+data class ReportOutcome(
+    val game: Game,
+    val recorded: Boolean,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/ReportedResult.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/ReportedResult.kt
@@ -1,0 +1,12 @@
+package com.lowbudgetlcs.domain.series.models
+
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+
+data class ReportedResult(
+    val winningTeamId: TeamId?,
+    val losingTeamId: TeamId?,
+    val tournamentCodeId: TournamentCodeId?,
+    val shortcode: Shortcode?,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/ITournamentCodeRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/ITournamentCodeRepository.kt
@@ -11,6 +11,8 @@ interface ITournamentCodeRepository {
 
     fun getBySeriesId(id: SeriesId): List<TournamentCode>
 
+    fun getByShortcode(shortcode: Shortcode): TournamentCode?
+
     fun insert(
         newCode: NewTournamentCode,
         shortcode: Shortcode,

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/TournamentCodeRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/tournamentcode/TournamentCodeRepository.kt
@@ -26,6 +26,9 @@ class TournamentCodeRepository(
             .fetch()
             .mapNotNull(::rowToTournamentCode)
 
+    override fun getByShortcode(shortcode: Shortcode) =
+        selectCodes().where(TOURNAMENT_CODES.SHORTCODE.eq(shortcode.value)).fetchOne()?.let(::rowToTournamentCode)
+
     override fun insert(
         newCode: NewTournamentCode,
         shortcode: Shortcode,

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -901,7 +901,9 @@ paths:
                 $ref: "#/components/schemas/GameDto"
         "200":
           description: |
-            The target already had a result. The existing game is returned and
+            The game was already recorded — either the targeted code already had
+            a result, or a bare report arrived after the callback had landed and
+            no code is still outstanding. The existing game is returned and
             nothing was written.
           content:
             application/json:
@@ -927,6 +929,8 @@ paths:
             Possible reasons:
             - Both `tournamentCodeId` and `shortcode` were given.
             - No winner was named and Riot has no record of the game.
+            - `winnerTeamId` is not a participant in the series.
+            - `loserTeamId` was given without `winnerTeamId`, or contradicts it.
           content:
             application/json:
               schema:
@@ -1611,8 +1615,8 @@ components:
         A game that was actually played. `tournamentCodeId` and `riotMatchId`
         are null for a custom game played without a code — Riot cannot serve
         custom match data, so those are recorded from a self-reported result.
-        `number` is derived from the count of games in the series, so a code
-        that is never played does not consume a game number.
+        `number` is derived as one past the highest number in the series, so a
+        code that is never played does not consume a game number.
       required:
         - id
         - seriesId
@@ -1637,7 +1641,7 @@ components:
           example: NA1_5102531894
         number:
           type: integer
-          description: Position within the series, derived as games played + 1.
+          description: Position within the series.
           example: 1
         createdAt:
           type: string

--- a/src/test/kotlin/services/SeriesReportResultTest.kt
+++ b/src/test/kotlin/services/SeriesReportResultTest.kt
@@ -1,0 +1,337 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.ReportedResult
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesResult
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGamesV5Dto
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentTeamV5Dto
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+
+private val HOME = TeamId(1)
+private val AWAY = TeamId(2)
+private val OUTSIDER = TeamId(3)
+private val REPORT_SERIES_ID = SeriesId(50)
+private val REPORT_CREATED_AT = Instant.parse("2026-07-14T23:12:04Z")
+
+private const val REPORT_PUUID = "aa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+private class ReportFixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    val games = mutableListOf<Game>()
+    private var nextId = 100
+
+    val series =
+        Series(
+            id = REPORT_SERIES_ID,
+            eventId = EventId(1),
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 3,
+            participants = Pair(HOME, AWAY),
+            result = null,
+            completed = false,
+            completedAt = null,
+            reopenedAt = null,
+        )
+
+    fun code(
+        id: Int,
+        shortcode: String,
+    ) = TournamentCode(
+        id = TournamentCodeId(id),
+        shortcode = Shortcode(shortcode),
+        blueTeamId = HOME,
+        redTeamId = AWAY,
+        seriesId = REPORT_SERIES_ID,
+        createdAt = Instant.parse("2026-07-14T22:58:31Z"),
+    )
+
+    fun riotGame(shortCode: String = "SHORT-A") =
+        RiotTournamentGamesV5Dto(
+            winningTeam = listOf(RiotTournamentTeamV5Dto(REPORT_PUUID)),
+            shortCode = shortCode,
+            gameId = 5102531894L,
+            region = "NA",
+        )
+
+    fun recordedGame(
+        codeId: Int?,
+        result: GameResult? = GameResult(HOME, AWAY),
+    ) = Game(
+        id = GameId(nextId++),
+        seriesId = REPORT_SERIES_ID,
+        tournamentCodeId = codeId?.let { TournamentCodeId(it) },
+        riotMatchId = null,
+        number = games.size + 1,
+        createdAt = REPORT_CREATED_AT,
+        result = result,
+    )
+
+    fun withSeries(
+        codes: List<TournamentCode>,
+        recorded: List<Game> = emptyList(),
+    ) {
+        games.clear()
+        games += recorded
+        every { seriesRepo.getById(REPORT_SERIES_ID) } returns series
+        every { gameRepo.getBySeriesId(REPORT_SERIES_ID) } answers { games.toList() }
+        every { codeRepo.getBySeriesId(REPORT_SERIES_ID) } returns codes
+        codes.forEach {
+            every { codeRepo.getById(it.id) } returns it
+            every { codeRepo.getByShortcode(it.shortcode) } returns it
+        }
+        every { gameRepo.insert(any()) } answers {
+            val new = firstArg<NewGame>()
+            val game =
+                Game(
+                    id = GameId(nextId++),
+                    seriesId = new.seriesId,
+                    tournamentCodeId = new.tournamentCodeId,
+                    riotMatchId = new.riotMatchId,
+                    number = games.size + 1,
+                    createdAt = REPORT_CREATED_AT,
+                    result = new.result,
+                )
+            games += game
+            game
+        }
+        every { seriesRepo.complete(any(), any(), any()) } returns series.copy(completed = true)
+    }
+}
+
+private fun reported(
+    winner: TeamId? = null,
+    loser: TeamId? = null,
+    codeId: Int? = null,
+    shortcode: String? = null,
+) = ReportedResult(
+    winningTeamId = winner,
+    losingTeamId = loser,
+    tournamentCodeId = codeId?.let { TournamentCodeId(it) },
+    shortcode = shortcode?.let { Shortcode(it) },
+)
+
+class SeriesReportResultTest :
+    StringSpec({
+        "targeting by tournamentCodeId attaches to that exact code" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A"), f.code(2, "SHORT-B")))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported(HOME, codeId = 2))
+
+            outcome.recorded shouldBe true
+            outcome.game.tournamentCodeId shouldBe TournamentCodeId(2)
+            outcome.game.result shouldBe GameResult(HOME, AWAY)
+        }
+
+        "targeting by shortcode attaches to that exact code" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A"), f.code(2, "SHORT-B")))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported(AWAY, shortcode = "SHORT-A"))
+
+            outcome.recorded shouldBe true
+            outcome.game.tournamentCodeId shouldBe TournamentCodeId(1)
+            outcome.game.result shouldBe GameResult(AWAY, HOME)
+        }
+
+        "giving both tournamentCodeId and shortcode is rejected" {
+            val f = ReportFixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.reportResult(REPORT_SERIES_ID, reported(HOME, codeId = 1, shortcode = "SHORT-A"))
+            }
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "with no code given the game is recorded against whichever code Riot names" {
+            val f = ReportFixture()
+            val older = f.code(1, "SHORT-OLDER")
+            val newer = f.code(2, "SHORT-NEWER")
+            coEvery { f.gateway.getGames(older.shortcode) } returns listOf(f.riotGame("SHORT-OLDER"))
+            coEvery { f.gateway.getGames(newer.shortcode) } returns emptyList()
+            f.withSeries(listOf(older, newer))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(HOME)
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported())
+
+            outcome.recorded shouldBe true
+            outcome.game.tournamentCodeId shouldBe TournamentCodeId(1)
+            f.games.size shouldBe 1
+        }
+
+        "a report Riot cannot account for is recorded codeless, leaving every code outstanding" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A"), f.code(2, "SHORT-B")))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported(HOME))
+
+            outcome.recorded shouldBe true
+            outcome.game.tournamentCodeId shouldBe null
+            outcome.game.riotMatchId shouldBe null
+            f.games.count { it.tournamentCodeId != null } shouldBe 0
+        }
+
+        "Riot being unreachable still records a codeless game" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } throws RiotApiException("503")
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported(HOME))
+
+            outcome.recorded shouldBe true
+            outcome.game.tournamentCodeId shouldBe null
+        }
+
+        "reporting a code that already has a result returns the existing game" {
+            val f = ReportFixture()
+            val existing = f.recordedGame(codeId = 1)
+            f.withSeries(listOf(f.code(1, "SHORT-A")), recorded = listOf(existing))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported(HOME, codeId = 1))
+
+            outcome.recorded shouldBe false
+            outcome.game shouldBe existing
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "with no winner named Riot's winner is used" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns listOf(f.riotGame())
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(AWAY)
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported())
+
+            outcome.recorded shouldBe true
+            outcome.game.result shouldBe GameResult(AWAY, HOME)
+        }
+
+        "with no winner named anywhere the report is rejected rather than silently dropped" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            shouldThrow<IllegalArgumentException> { f.service.reportResult(REPORT_SERIES_ID, reported()) }
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "a bare report after the callback already landed is a no-op, not a duplicate" {
+            val f = ReportFixture()
+            val existing = f.recordedGame(codeId = 1)
+            f.withSeries(listOf(f.code(1, "SHORT-A")), recorded = listOf(existing))
+
+            val outcome = f.service.reportResult(REPORT_SERIES_ID, reported())
+
+            outcome.recorded shouldBe false
+            outcome.game shouldBe existing
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "a code belonging to another series is not found" {
+            val f = ReportFixture()
+            val foreign = f.code(9, "SHORT-FOREIGN").copy(seriesId = SeriesId(51))
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.codeRepo.getById(TournamentCodeId(9)) } returns foreign
+
+            shouldThrow<NoSuchElementException> {
+                f.service.reportResult(REPORT_SERIES_ID, reported(HOME, codeId = 9))
+            }
+        }
+
+        "an unknown shortcode is not found" {
+            val f = ReportFixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+            every { f.codeRepo.getByShortcode(Shortcode("NOPE")) } returns null
+
+            shouldThrow<NoSuchElementException> {
+                f.service.reportResult(REPORT_SERIES_ID, reported(HOME, shortcode = "NOPE"))
+            }
+        }
+
+        "a winner outside the series is rejected" {
+            val f = ReportFixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            shouldThrow<IllegalArgumentException> { f.service.reportResult(REPORT_SERIES_ID, reported(OUTSIDER)) }
+        }
+
+        "a loser that contradicts the winner is rejected" {
+            val f = ReportFixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.reportResult(REPORT_SERIES_ID, reported(winner = HOME, loser = HOME))
+            }
+        }
+
+        "a loser without a winner is rejected" {
+            val f = ReportFixture()
+            f.withSeries(listOf(f.code(1, "SHORT-A")))
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.reportResult(REPORT_SERIES_ID, reported(loser = AWAY))
+            }
+        }
+
+        "a report that clinches the series closes it" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A")), recorded = listOf(f.recordedGame(codeId = 1)))
+
+            f.service.reportResult(REPORT_SERIES_ID, reported(HOME))
+
+            verify(exactly = 1) {
+                f.seriesRepo.complete(REPORT_SERIES_ID, any(), SeriesResult(HOME, AWAY))
+            }
+        }
+
+        "a mixed series counts coded and codeless games alike" {
+            val f = ReportFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            f.withSeries(listOf(f.code(1, "SHORT-A")), recorded = listOf(f.recordedGame(codeId = 1)))
+
+            f.service.reportResult(REPORT_SERIES_ID, reported(HOME))
+
+            f.games.map { it.tournamentCodeId } shouldBe listOf(TournamentCodeId(1), null)
+            f.games.mapNotNull { it.result?.winningTeamId } shouldBe listOf(HOME, HOME)
+        }
+    })


### PR DESCRIPTION
Closes #198. Stacked on #212 (issue #197) — review that first.

Adds `POST /api/v1/series/{seriesId}/results`, the single result-reporting entry point for both captains and staff, and the fallback for the one case Riot genuinely cannot serve: a custom game played with no tournament code.

## Targeting never guesses

| Given | Behaviour |
|---|---|
| `tournamentCodeId` **or** `shortcode` | trusted, attached to that exact code |
| both | **422** |
| neither, Riot attributes a game | recorded against **the code Riot names**, with Riot's winner |
| neither, Riot attributes nothing | recorded **codeless**, both `tournament_code_id` and `riot_match_id` null |
| neither, Riot unreachable | recorded codeless, unverified codes logged at WARN |

Recording codeless deliberately leaves every outstanding code outstanding, so the next `refreshFromRiot` still asks Riot about it (TC5). The rejected alternative — attaching to "the most recent code with no result" — would mark an unplayed code as played and let a later callback for the code that *was* used create a second game.

Winner resolution follows the same rule: with no winner named the pull supplies one, and the caller's declared winner is used only when Riot has no record. A captain reporting a coded game asserts nothing.

## Two decisions beyond the ticket

**1. A bare report after the callback already landed is a 200, not a 422.**

The ticket defines idempotency per target, which leaves the untargeted case exposed. Without this branch: callback records game 2 → captain hits report → nothing is outstanding, so Riot has nothing to attribute → 422 "name a winner" → the client supplies one → **a second, codeless game for one match**. That is exactly the double-count #189 is written to prevent, so the endpoint now returns the recorded game instead.

The guard is narrow — no declared winner, **and** no code still outstanding, **and** a recorded game exists. A genuine custom game in a series with a bum code still has that code outstanding, so TC5 is unaffected.

**2. Declared winners are validated against the series.** `winnerTeamId` must be a participant; `loserTeamId` is optional and, when given, must be the other participant. A loser without a winner is rejected rather than silently ignored. All 422, all added to the spec's 422 description.

## Known gap, not fixed here

Two identical **codeless** reports create two games. Per-code idempotency cannot catch it — there is no code to key on — and content-based dedup would break a legitimate 2-0 in custom games. It requires a human to assert a winner twice, so the blast radius is the same as any non-idempotent POST without an idempotency key. Worth an idempotency key or a client-side guard later; flagging rather than inventing semantics the ticket does not specify.

Separately, the friendly **409** for a duplicate `riot_match_id` (TC17) is still #201's job. This endpoint never sets `riot_match_id`, so it can only surface from the pull path, where it currently collapses to a 500.

## Also here

- `ITournamentCodeRepository.getByShortcode` — a human reporting a result has the code from their game client, not a database id.
- `GameDto` / `GameResultDto`, matching the shapes #191 put in the spec.
- `createGame`'s inline Riot try/catch folded into `refreshQuietly`, now shared with the report path.
- Spec: `GameDto`'s stale "`number` is derived from the count of games" corrected to MAX + 1, matching #210. Same correction was made on #198 and #189.
- Import ordering in `SeriesService`, a lint violation left by #197.

## Testing

17 unit tests (`SeriesReportResultTest`) covering every acceptance criterion on the ticket, plus 2 integration tests for the shortcode lookup. The spec uses a stateful `gameRepo` fake so the before/after-pull sequencing is exercised for real rather than stubbed per call.

Three mutations were verified to fail the suite:

| Mutation | Killed by |
|---|---|
| drop the Riot-attributed branch (reintroduce guessing) | `recorded against whichever code Riot names`, `Riot's winner is used` |
| drop the already-landed no-op | `a bare report after the callback already landed is a no-op` |
| drop per-code idempotency | `reporting a code that already has a result returns the existing game` |

`assemble`, `test` and `itest` all pass locally — the same three tasks CI runs.
