### PR TITLE
feat: Series completion and reopen endpoints

### DIFF
--- a/src/itest/kotlin/SeriesRepositoryTest.kt
+++ b/src/itest/kotlin/SeriesRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.lowbudgetlcs.domain.event.models.types.EventStage
 import com.lowbudgetlcs.domain.event.models.types.EventStatus
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.SeriesResult
 import com.lowbudgetlcs.domain.series.models.filterByCompletion
 import com.lowbudgetlcs.domain.team.models.NewTeam
 import com.lowbudgetlcs.domain.team.models.Team
@@ -24,6 +25,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
+import org.jooq.storage.tables.references.GAMES
 import org.jooq.storage.tables.references.SERIES_RESULTS
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.MountableFile
@@ -118,6 +120,42 @@ class SeriesRepositoryTest :
             completed.completedAt shouldBe at
             completed.reopenedAt.shouldBeNull()
             repo.getById(created.id)?.completed shouldBe true
+        }
+
+        test("a forfeit writes series_results with no games played") {
+            val created = repo.insert(newSeries)
+            created.shouldNotBeNull()
+
+            val completed =
+                repo.complete(
+                    created.id,
+                    Instant.parse("2026-07-14T23:12:04Z"),
+                    SeriesResult(team1.id, team2.id),
+                )
+            completed.shouldNotBeNull()
+
+            completed.completed shouldBe true
+            completed.result?.winningTeamId shouldBe team1.id
+            completed.result?.losingTeamId shouldBe team2.id
+            dsl.fetchCount(GAMES, GAMES.SERIES_ID.eq(created.id.value)) shouldBe 0
+            dsl.fetchCount(SERIES_RESULTS, SERIES_RESULTS.SERIES_ID.eq(created.id.value)) shouldBe 1
+        }
+
+        test("completing twice overwrites the result rather than duplicating the row") {
+            val created = repo.insert(newSeries)
+            created.shouldNotBeNull()
+            repo.complete(created.id, Instant.parse("2026-07-14T23:12:04Z"), SeriesResult(team1.id, team2.id))
+
+            val corrected =
+                repo.complete(
+                    created.id,
+                    Instant.parse("2026-07-15T10:00:00Z"),
+                    SeriesResult(team2.id, team1.id),
+                )
+            corrected.shouldNotBeNull()
+
+            corrected.result?.winningTeamId shouldBe team2.id
+            dsl.fetchCount(SERIES_RESULTS, SERIES_RESULTS.SERIES_ID.eq(created.id.value)) shouldBe 1
         }
 
         test("reopen clears completion, stamps reopenedAt and preserves series_results") {

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/CompleteSeriesDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/CompleteSeriesDto.kt
@@ -1,0 +1,9 @@
+package com.lowbudgetlcs.api.dto.series
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CompleteSeriesDto(
+    val winnerTeamId: Int? = null,
+    val loserTeamId: Int? = null,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDto.kt
@@ -1,7 +1,9 @@
 package com.lowbudgetlcs.api.dto.series
 
 import com.lowbudgetlcs.domain.event.models.types.EventStage
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
+import java.time.Instant
 
 @Serializable
 data class SeriesDto(
@@ -10,4 +12,9 @@ data class SeriesDto(
     val teamIds: List<Int>,
     val totalGames: Int,
     val eventStage: EventStage,
+    val completed: Boolean,
+    @Contextual
+    val completedAt: Instant? = null,
+    @Contextual
+    val reopenedAt: Instant? = null,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
@@ -14,6 +14,9 @@ fun Series.toDto(): SeriesDto =
         teamIds = participants.toList().map { it.value },
         totalGames = totalGames,
         eventStage = eventStage,
+        completed = completed,
+        completedAt = completedAt,
+        reopenedAt = reopenedAt,
     )
 
 fun NewSeriesDto.toNewSeries(eventId: Int): NewSeries =

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
@@ -15,4 +15,10 @@ class SeriesResources {
         val parent: SeriesResources = SeriesResources(),
         val seriesId: Int,
     )
+
+    @Resource("{seriesId}/complete")
+    data class Complete(
+        val parent: SeriesResources = SeriesResources(),
+        val seriesId: Int,
+    )
 }

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
@@ -5,11 +5,15 @@ import com.lowbudgetlcs.api.dto.games.ReportResultDto
 import com.lowbudgetlcs.api.dto.games.toDto
 import com.lowbudgetlcs.api.dto.games.toNewTournamentCode
 import com.lowbudgetlcs.api.dto.games.toReportedResult
+import com.lowbudgetlcs.api.dto.series.CompleteSeriesDto
+import com.lowbudgetlcs.api.dto.series.toDto
 import com.lowbudgetlcs.domain.series.ISeriesService
 import com.lowbudgetlcs.domain.series.models.toSeriesId
+import com.lowbudgetlcs.domain.team.models.toTeamId
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.request.receive
+import io.ktor.server.resources.delete
 import io.ktor.server.resources.post
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -26,6 +30,21 @@ fun Route.seriesRoutesV1(seriesService: ISeriesService) {
             logger.debug(dto.toString())
             val created = seriesService.createGame(dto.toNewTournamentCode(route.seriesId))
             call.respond(HttpStatusCode.Created, created.toDto())
+        }
+        post<SeriesResources.Complete> { route ->
+            val dto = call.receive<CompleteSeriesDto>()
+            logger.debug(dto.toString())
+            val series =
+                seriesService.completeSeries(
+                    route.seriesId.toSeriesId(),
+                    dto.winnerTeamId?.toTeamId(),
+                    dto.loserTeamId?.toTeamId(),
+                )
+            call.respond(HttpStatusCode.OK, series.toDto())
+        }
+        delete<SeriesResources.Complete> { route ->
+            val series = seriesService.reopenSeries(route.seriesId.toSeriesId())
+            call.respond(HttpStatusCode.OK, series.toDto())
         }
         post<SeriesResources.Results> { route ->
             val dto = call.receive<ReportResultDto>()

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -9,6 +9,7 @@ import com.lowbudgetlcs.domain.series.models.ReportOutcome
 import com.lowbudgetlcs.domain.series.models.ReportedResult
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
 
 interface ISeriesService {
     /**
@@ -49,6 +50,14 @@ interface ISeriesService {
         id: SeriesId,
         report: ReportedResult,
     ): ReportOutcome
+
+    fun completeSeries(
+        id: SeriesId,
+        winningTeamId: TeamId?,
+        losingTeamId: TeamId?,
+    ): Series
+
+    fun reopenSeries(id: SeriesId): Series
 
     /**
      * Remove a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -205,24 +205,54 @@ class SeriesService(
         return game
     }
 
+    override fun completeSeries(
+        id: SeriesId,
+        winningTeamId: TeamId?,
+        losingTeamId: TeamId?,
+    ): Series {
+        val series = getSeries(id)
+        check(!series.completed) {
+            "Series '${id.value}' is already complete. Reopen it before completing it again."
+        }
+        val result = winnerAndLoser(series, winningTeamId, losingTeamId)?.let { SeriesResult(it.first, it.second) }
+        logger.info("Closing series '$id' manually, winner '${result?.winningTeamId}'.")
+        return seriesRepo.complete(id, Instant.now(), result)
+            ?: throw DatabaseException("Failed to complete series with id '${id.value}'.")
+    }
+
+    override fun reopenSeries(id: SeriesId): Series {
+        val series = getSeries(id)
+        check(series.completed) { "Series '${id.value}' is not complete, so it cannot be reopened." }
+        logger.info("Reopening series '$id'.")
+        return seriesRepo.reopen(id, Instant.now())
+            ?: throw DatabaseException("Failed to reopen series with id '${id.value}'.")
+    }
+
     private fun declaredResult(
         series: Series,
         report: ReportedResult,
-    ): GameResult? {
-        val winner = report.winningTeamId
-        if (winner == null) {
-            require(report.losingTeamId == null) { "A losing team cannot be given without a winning team." }
+    ): GameResult? =
+        winnerAndLoser(series, report.winningTeamId, report.losingTeamId)
+            ?.let { GameResult(it.first, it.second) }
+
+    private fun winnerAndLoser(
+        series: Series,
+        winningTeamId: TeamId?,
+        losingTeamId: TeamId?,
+    ): Pair<TeamId, TeamId>? {
+        if (winningTeamId == null) {
+            require(losingTeamId == null) { "A losing team cannot be given without a winning team." }
             return null
         }
         val (first, second) = series.participants
-        require(winner == first || winner == second) {
-            "Team '${winner.value}' is not a participant in series '${series.id.value}'."
+        require(winningTeamId == first || winningTeamId == second) {
+            "Team '${winningTeamId.value}' is not a participant in series '${series.id.value}'."
         }
-        val loser = if (winner == first) second else first
-        report.losingTeamId?.let {
+        val loser = if (winningTeamId == first) second else first
+        losingTeamId?.let {
             require(it == loser) { "Team '${it.value}' is not the losing participant in series '${series.id.value}'." }
         }
-        return GameResult(winner, loser)
+        return winningTeamId to loser
     }
 
     private fun resolveTarget(

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -970,6 +970,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "409":
+          description: |
+            The series is already complete. Reopen it with `DELETE` before
+            completing it again, so the reopen is recorded rather than the
+            previous result being silently overwritten.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "422":
           description: Invalid input, for example a winner that is not in this series.
           content:
@@ -1001,6 +1010,12 @@ paths:
                 $ref: "#/components/schemas/SeriesDto"
         "404":
           description: Series not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The series is not complete, so there is nothing to reopen.
           content:
             application/json:
               schema:
@@ -2192,6 +2207,17 @@ components:
           format: date-time
           nullable: true
           description: When the series was completed. Null while `completed` is false.
+          example: null
+        reopenedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When staff last reopened this series. Once stamped it is never
+            cleared, and it permanently suppresses automatic completion for
+            this series — otherwise a series that already meets the win
+            threshold would slam shut again on the next recorded result.
+            Manual completion still works.
           example: null
 
     SeriesWithGamesDto:

--- a/src/test/kotlin/services/SeriesCompletionTest.kt
+++ b/src/test/kotlin/services/SeriesCompletionTest.kt
@@ -1,0 +1,204 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesResult
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.Instant
+
+private val WINNER = TeamId(1)
+private val LOSER = TeamId(2)
+private val STRANGER = TeamId(3)
+private val COMPLETION_SERIES_ID = SeriesId(60)
+
+private class CompletionFixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    fun series(
+        completed: Boolean = false,
+        completedAt: Instant? = null,
+        reopenedAt: Instant? = null,
+    ) = Series(
+        id = COMPLETION_SERIES_ID,
+        eventId = EventId(1),
+        eventStage = EventStage.PLAYOFFS,
+        totalGames = 3,
+        participants = Pair(WINNER, LOSER),
+        result = null,
+        completed = completed,
+        completedAt = completedAt,
+        reopenedAt = reopenedAt,
+    )
+
+    fun withSeries(series: Series) {
+        every { seriesRepo.getById(COMPLETION_SERIES_ID) } returns series
+        every { seriesRepo.complete(any(), any(), any()) } returns series.copy(completed = true)
+        every { seriesRepo.reopen(any(), any()) } returns
+            series.copy(completed = false, completedAt = null, reopenedAt = Instant.now())
+    }
+}
+
+class SeriesCompletionTest :
+    StringSpec({
+        "completing an open series sets the flags and records the result" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            f.service.completeSeries(COMPLETION_SERIES_ID, WINNER, LOSER)
+
+            verify(exactly = 1) {
+                f.seriesRepo.complete(COMPLETION_SERIES_ID, any(), SeriesResult(WINNER, LOSER))
+            }
+        }
+
+        "a forfeit closes a series with zero games played" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            f.service.completeSeries(COMPLETION_SERIES_ID, WINNER, null)
+
+            verify(exactly = 1) {
+                f.seriesRepo.complete(COMPLETION_SERIES_ID, any(), SeriesResult(WINNER, LOSER))
+            }
+            verify(exactly = 0) { f.gameRepo.getBySeriesId(any()) }
+        }
+
+        "closing with no winner named sets the flags without writing a result" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            f.service.completeSeries(COMPLETION_SERIES_ID, null, null)
+
+            verify(exactly = 1) { f.seriesRepo.complete(COMPLETION_SERIES_ID, any(), null) }
+        }
+
+        "completing an already-complete series is a conflict, not a silent overwrite" {
+            val f = CompletionFixture()
+            f.withSeries(f.series(completed = true, completedAt = Instant.parse("2026-07-14T23:12:04Z")))
+
+            shouldThrow<IllegalStateException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, LOSER, WINNER)
+            }
+
+            verify(exactly = 0) { f.seriesRepo.complete(any(), any(), any()) }
+        }
+
+        "a winner outside the series is rejected on its own, not via the loser check" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, STRANGER, null)
+            }
+
+            verify(exactly = 0) { f.seriesRepo.complete(any(), any(), any()) }
+        }
+
+        "a winner outside the series is rejected when a loser is named too" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, STRANGER, LOSER)
+            }
+        }
+
+        "a loser that contradicts the winner is rejected" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, WINNER, WINNER)
+            }
+        }
+
+        "a loser without a winner is rejected" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, null, LOSER)
+            }
+        }
+
+        "completing an unknown series is not found" {
+            val f = CompletionFixture()
+            every { f.seriesRepo.getById(COMPLETION_SERIES_ID) } returns null
+
+            shouldThrow<NoSuchElementException> {
+                f.service.completeSeries(COMPLETION_SERIES_ID, WINNER, LOSER)
+            }
+        }
+
+        "reopening a complete series stamps reopenedAt" {
+            val f = CompletionFixture()
+            f.withSeries(f.series(completed = true, completedAt = Instant.parse("2026-07-14T23:12:04Z")))
+            val stamped = slot<Instant>()
+
+            val reopened = f.service.reopenSeries(COMPLETION_SERIES_ID)
+
+            verify(exactly = 1) { f.seriesRepo.reopen(COMPLETION_SERIES_ID, capture(stamped)) }
+            stamped.isCaptured shouldBe true
+            reopened.completed shouldBe false
+        }
+
+        "reopening a series that is not complete is a conflict" {
+            val f = CompletionFixture()
+            f.withSeries(f.series())
+
+            shouldThrow<IllegalStateException> { f.service.reopenSeries(COMPLETION_SERIES_ID) }
+
+            verify(exactly = 0) { f.seriesRepo.reopen(any(), any()) }
+        }
+
+        "reopening an unknown series is not found" {
+            val f = CompletionFixture()
+            every { f.seriesRepo.getById(COMPLETION_SERIES_ID) } returns null
+
+            shouldThrow<NoSuchElementException> { f.service.reopenSeries(COMPLETION_SERIES_ID) }
+        }
+
+        "a reopened series is not closed again by a later result" {
+            val f = CompletionFixture()
+            val reopened = f.series(reopenedAt = Instant.parse("2026-07-15T09:00:00Z"))
+            f.withSeries(reopened)
+
+            f.service.evaluateCompletion(COMPLETION_SERIES_ID)
+
+            verify(exactly = 0) { f.seriesRepo.complete(any(), any(), any()) }
+            verify(exactly = 0) { f.gameRepo.getBySeriesId(any()) }
+        }
+
+        "manual completion still works on a reopened series" {
+            val f = CompletionFixture()
+            f.withSeries(f.series(reopenedAt = Instant.parse("2026-07-15T09:00:00Z")))
+
+            f.service.completeSeries(COMPLETION_SERIES_ID, WINNER, LOSER)
+
+            verify(exactly = 1) {
+                f.seriesRepo.complete(COMPLETION_SERIES_ID, any(), SeriesResult(WINNER, LOSER))
+            }
+        }
+    })


### PR DESCRIPTION
Closes #199. Stacked on #213 (issue #198) — review that first.

Adds the two staff paths that recorded results cannot express.

## `POST /api/v1/series/{seriesId}/complete`

Manual close, and the forfeit path — a winner with **zero games played**, which auto-close has nothing to count. Body `{ winnerTeamId?, loserTeamId? }`; with no winner the flags are set and no `series_results` row is written.

## `DELETE /api/v1/series/{seriesId}/complete`

Clears `completed`/`completed_at`, stamps `reopened_at`, preserves `series_results`. The stamp is what stops auto-close slamming a reopened series shut again on the very next recorded result.

## Both conflicts are explicit, not a 500 or a silent write

The ticket asks that completing an already-complete series be "handled explicitly". Two calls, both **409**:

| Case | Why not the alternative |
|---|---|
| Completing an already-complete series | Overwriting discards the previous result with no record anything changed. `DELETE` already exists to make that deliberate and auditable, so the 409 points there. |
| Reopening a series that is not complete | Stamping `reopened_at` on an open series permanently disables auto-close for it — a footgun with no stated use case. |

Manual completion deliberately **still works on a reopened series**. `reopened_at` suppresses *automatic* closure only; a human closing it by hand is the intended escape hatch, and there is a test pinning that.

## `SeriesDto` drift closed

The spec has declared `completed`/`completedAt` on `SeriesDto` since #191, but the Kotlin DTO never grew them — #193 added the `completed` *filter* without the fields. Both endpoints here return `SeriesDto`, so without this they'd answer with a body that can't show the flag they just changed.

`reopenedAt` is added too, which settles the question parked on this ticket back in #191: the `DELETE` response is unverifiable without it. Documented in the spec as never-cleared and permanently suppressing auto-close, since that is the surprising part.

All three are additive, so existing consumers are unaffected.

## Also

Winner validation is now shared with the report path via `winnerAndLoser` — the winner must be a participant, and a named loser must be the other participant.

## Testing

14 unit tests, plus 2 integration tests covering the forfeit write (`series_results` row, zero `games` rows) and the `series_results` upsert on repeat completion.

**Mutation testing caught a weak assertion of mine, not a code bug.** Bypassing the participant check initially left the suite green: the out-of-series-winner test passed a loser too, so the contradictory-loser check threw first and the participant check was never isolated. Split into two cases — one with no loser named — and the mutation now fails on `a winner outside the series is rejected on its own, not via the loser check`.

| Mutation | Killed by |
|---|---|
| already-complete guard removed | `completing an already-complete series is a conflict, not a silent overwrite` |
| reopen-requires-complete guard removed | `reopening a series that is not complete is a conflict` |
| participant check bypassed | `a winner outside the series is rejected on its own, not via the loser check` |

`assemble`, `test` (127 tests) and `itest` (66 tests) all pass locally — the three tasks CI runs.

Note for anyone reproducing: passing two `--tests` filters to Gradle in one invocation reports "No tests found" against this Kotest setup. Filter one spec at a time.
