### PR TITLE
feat: GET /v1/series/{seriesId} with codes and games

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesDtoMappers.kt
@@ -1,10 +1,12 @@
 package com.lowbudgetlcs.api.dto.series
 
+import com.lowbudgetlcs.api.dto.games.toDto
 import com.lowbudgetlcs.domain.event.models.toEventId
 import com.lowbudgetlcs.domain.event.models.toStage
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.SeriesQuery
+import com.lowbudgetlcs.domain.series.models.SeriesWithGames
 import com.lowbudgetlcs.domain.team.models.toTeamId
 
 fun Series.toDto(): SeriesDto =
@@ -32,4 +34,20 @@ fun SeriesFilterParams.toQuery(): SeriesQuery =
         teamIds = teamIds?.map { it.toTeamId() },
         eventStage = stage,
         completed = completed,
+    )
+
+fun SeriesWithGames.toDto(): SeriesWithGamesDto =
+    SeriesWithGamesDto(
+        id = id.value,
+        eventId = eventId.value,
+        teamIds = participants.toList().map { it.value },
+        totalGames = totalGames,
+        eventStage = eventStage,
+        completed = completed,
+        completedAt = completedAt,
+        reopenedAt = reopenedAt,
+        tournamentCodes = tournamentCodes.map { it.toDto() },
+        games = games.map { it.toDto() },
+        lastCodeIssuedAt = lastCodeIssuedAt,
+        lastGameAt = lastGameAt,
     )

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesWithGamesDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/SeriesWithGamesDto.kt
@@ -1,0 +1,28 @@
+package com.lowbudgetlcs.api.dto.series
+
+import com.lowbudgetlcs.api.dto.games.GameDto
+import com.lowbudgetlcs.api.dto.games.TournamentCodeDto
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@Serializable
+data class SeriesWithGamesDto(
+    val id: Int,
+    val eventId: Int?,
+    val teamIds: List<Int>,
+    val totalGames: Int,
+    val eventStage: EventStage,
+    val completed: Boolean,
+    @Contextual
+    val completedAt: Instant? = null,
+    @Contextual
+    val reopenedAt: Instant? = null,
+    val tournamentCodes: List<TournamentCodeDto>,
+    val games: List<GameDto>,
+    @Contextual
+    val lastCodeIssuedAt: Instant? = null,
+    @Contextual
+    val lastGameAt: Instant? = null,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
@@ -4,6 +4,12 @@ import io.ktor.resources.Resource
 
 @Resource("/")
 class SeriesResources {
+    @Resource("{seriesId}")
+    data class ById(
+        val parent: SeriesResources = SeriesResources(),
+        val seriesId: Int,
+    )
+
     @Resource("{seriesId}/game")
     data class TournamentCode(
         val parent: SeriesResources = SeriesResources(),

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.request.receive
 import io.ktor.server.resources.delete
+import io.ktor.server.resources.get
 import io.ktor.server.resources.post
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -30,6 +31,10 @@ fun Route.seriesRoutesV1(seriesService: ISeriesService) {
             logger.debug(dto.toString())
             val created = seriesService.createGame(dto.toNewTournamentCode(route.seriesId))
             call.respond(HttpStatusCode.Created, created.toDto())
+        }
+        get<SeriesResources.ById> { route ->
+            val series = seriesService.getSeriesWithGames(route.seriesId.toSeriesId())
+            call.respond(series.toDto())
         }
         post<SeriesResources.Complete> { route ->
             val dto = call.receive<CompleteSeriesDto>()

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -8,6 +8,7 @@ import com.lowbudgetlcs.domain.series.models.RefreshOutcome
 import com.lowbudgetlcs.domain.series.models.ReportOutcome
 import com.lowbudgetlcs.domain.series.models.ReportedResult
 import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.SeriesWithGames
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.types.TeamId
 
@@ -58,6 +59,8 @@ interface ISeriesService {
     ): Series
 
     fun reopenSeries(id: SeriesId): Series
+
+    fun getSeriesWithGames(id: SeriesId): SeriesWithGames
 
     /**
      * Remove a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -19,6 +19,8 @@ import com.lowbudgetlcs.domain.series.models.ReportOutcome
 import com.lowbudgetlcs.domain.series.models.ReportedResult
 import com.lowbudgetlcs.domain.series.models.Series
 import com.lowbudgetlcs.domain.series.models.SeriesResult
+import com.lowbudgetlcs.domain.series.models.SeriesWithGames
+import com.lowbudgetlcs.domain.series.models.toSeriesWithGames
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.domain.team.models.types.TeamId
 import com.lowbudgetlcs.equalsIgnoreOrder
@@ -70,6 +72,12 @@ class SeriesService(
     override fun getSeries(id: SeriesId): Series {
         logger.debug("Fetching series '$id'...")
         return seriesRepo.getById(id) ?: throw NoSuchElementException("Series not found")
+    }
+
+    override fun getSeriesWithGames(id: SeriesId): SeriesWithGames {
+        logger.debug("Fetching series '$id' with codes and games...")
+        val series = getSeries(id)
+        return series.toSeriesWithGames(codeRepo.getBySeriesId(id), gameRepo.getBySeriesId(id))
     }
 
     override fun evaluateCompletion(id: SeriesId): Series {

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Extensions.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/Extensions.kt
@@ -1,5 +1,7 @@
 package com.lowbudgetlcs.domain.series.models
 
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
 import com.lowbudgetlcs.domain.series.models.types.SeriesId
 import com.lowbudgetlcs.equalsIgnoreOrder
 
@@ -22,3 +24,21 @@ fun List<Series>.filterByParticipants(query: SeriesQuery?): List<Series> {
         else -> this.filter { s -> s.participants.toList().equalsIgnoreOrder(participants) }
     }
 }
+
+fun Series.toSeriesWithGames(
+    tournamentCodes: List<TournamentCode>,
+    games: List<Game>,
+): SeriesWithGames =
+    SeriesWithGames(
+        id = id,
+        eventId = eventId,
+        eventStage = eventStage,
+        totalGames = totalGames,
+        participants = participants,
+        result = result,
+        completed = completed,
+        completedAt = completedAt,
+        reopenedAt = reopenedAt,
+        tournamentCodes = tournamentCodes,
+        games = games,
+    )

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/models/SeriesWithGames.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/models/SeriesWithGames.kt
@@ -1,0 +1,26 @@
+package com.lowbudgetlcs.domain.series.models
+
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import java.time.Instant
+
+data class SeriesWithGames(
+    val id: SeriesId,
+    val eventId: EventId,
+    val eventStage: EventStage,
+    val totalGames: Int,
+    val participants: Pair<TeamId, TeamId>,
+    val result: SeriesResult?,
+    val completed: Boolean,
+    val completedAt: Instant?,
+    val reopenedAt: Instant?,
+    val tournamentCodes: List<TournamentCode>,
+    val games: List<Game>,
+) {
+    val lastCodeIssuedAt: Instant? get() = tournamentCodes.maxOfOrNull { it.createdAt }
+    val lastGameAt: Instant? get() = games.maxOfOrNull { it.createdAt }
+}

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -2264,6 +2264,14 @@ components:
           format: date-time
           nullable: true
           example: null
+        reopenedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            When staff last reopened this series. Never cleared once stamped,
+            and permanently suppresses automatic completion.
+          example: null
         tournamentCodes:
           type: array
           items:

--- a/src/test/kotlin/services/SeriesWithGamesTest.kt
+++ b/src/test/kotlin/services/SeriesWithGamesTest.kt
@@ -1,0 +1,191 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+
+private val BLUE = TeamId(1)
+private val RED = TeamId(2)
+private val VIEW_SERIES_ID = SeriesId(70)
+
+private val FIRST_CODE_AT = Instant.parse("2026-07-14T22:00:00Z")
+private val SECOND_CODE_AT = Instant.parse("2026-07-14T23:41:09Z")
+private val FIRST_GAME_AT = Instant.parse("2026-07-14T22:30:00Z")
+private val SECOND_GAME_AT = Instant.parse("2026-07-14T23:12:04Z")
+
+private class ViewFixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    val series =
+        Series(
+            id = VIEW_SERIES_ID,
+            eventId = EventId(1),
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 3,
+            participants = Pair(BLUE, RED),
+            result = null,
+            completed = false,
+            completedAt = null,
+            reopenedAt = null,
+        )
+
+    fun code(
+        id: Int,
+        createdAt: Instant,
+    ) = TournamentCode(
+        id = TournamentCodeId(id),
+        shortcode = Shortcode("SHORT-$id"),
+        blueTeamId = BLUE,
+        redTeamId = RED,
+        seriesId = VIEW_SERIES_ID,
+        createdAt = createdAt,
+    )
+
+    fun game(
+        id: Int,
+        codeId: Int?,
+        number: Int,
+        createdAt: Instant,
+    ) = Game(
+        id = GameId(id),
+        seriesId = VIEW_SERIES_ID,
+        tournamentCodeId = codeId?.let { TournamentCodeId(it) },
+        riotMatchId = null,
+        number = number,
+        createdAt = createdAt,
+        result = GameResult(BLUE, RED),
+    )
+
+    fun withContents(
+        codes: List<TournamentCode>,
+        games: List<Game>,
+    ) {
+        every { seriesRepo.getById(VIEW_SERIES_ID) } returns series
+        every { codeRepo.getBySeriesId(VIEW_SERIES_ID) } returns codes
+        every { gameRepo.getBySeriesId(VIEW_SERIES_ID) } returns games
+    }
+}
+
+class SeriesWithGamesTest :
+    StringSpec({
+        "returns both collections and both timestamps" {
+            val f = ViewFixture()
+            f.withContents(
+                codes = listOf(f.code(1, FIRST_CODE_AT), f.code(2, SECOND_CODE_AT)),
+                games = listOf(f.game(10, 1, 1, FIRST_GAME_AT), f.game(11, 2, 2, SECOND_GAME_AT)),
+            )
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.tournamentCodes.map { it.id } shouldBe listOf(TournamentCodeId(1), TournamentCodeId(2))
+            view.games.map { it.id } shouldBe listOf(GameId(10), GameId(11))
+            view.lastCodeIssuedAt shouldBe SECOND_CODE_AT
+            view.lastGameAt shouldBe SECOND_GAME_AT
+        }
+
+        "a bum code appears in tournamentCodes but not in games" {
+            val f = ViewFixture()
+            f.withContents(
+                codes = listOf(f.code(1, FIRST_CODE_AT), f.code(2, SECOND_CODE_AT)),
+                games = listOf(f.game(10, 1, 1, FIRST_GAME_AT)),
+            )
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.tournamentCodes.size shouldBe 2
+            view.games.size shouldBe 1
+            view.games.single().tournamentCodeId shouldBe TournamentCodeId(1)
+        }
+
+        "lastCodeIssuedAt reflects the newest code even when it is not last in the list" {
+            val f = ViewFixture()
+            f.withContents(
+                codes = listOf(f.code(1, SECOND_CODE_AT), f.code(2, FIRST_CODE_AT)),
+                games = emptyList(),
+            )
+
+            f.service.getSeriesWithGames(VIEW_SERIES_ID).lastCodeIssuedAt shouldBe SECOND_CODE_AT
+        }
+
+        "lastGameAt is null when no game has been recorded" {
+            val f = ViewFixture()
+            f.withContents(codes = listOf(f.code(1, FIRST_CODE_AT)), games = emptyList())
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.lastGameAt.shouldBeNull()
+            view.lastCodeIssuedAt shouldBe FIRST_CODE_AT
+        }
+
+        "both timestamps are null on a series with nothing issued or played" {
+            val f = ViewFixture()
+            f.withContents(codes = emptyList(), games = emptyList())
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.lastCodeIssuedAt.shouldBeNull()
+            view.lastGameAt.shouldBeNull()
+        }
+
+        "a codeless game is still counted as a game played" {
+            val f = ViewFixture()
+            f.withContents(
+                codes = listOf(f.code(1, FIRST_CODE_AT)),
+                games = listOf(f.game(10, null, 1, FIRST_GAME_AT)),
+            )
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.games.size shouldBe 1
+            view.games.single().tournamentCodeId shouldBe null
+            view.lastGameAt shouldBe FIRST_GAME_AT
+        }
+
+        "the series fields are carried through unchanged" {
+            val f = ViewFixture()
+            f.withContents(codes = emptyList(), games = emptyList())
+
+            val view = f.service.getSeriesWithGames(VIEW_SERIES_ID)
+
+            view.id shouldBe VIEW_SERIES_ID
+            view.totalGames shouldBe 3
+            view.eventStage shouldBe EventStage.PLAYOFFS
+            view.participants shouldBe Pair(BLUE, RED)
+            view.completed shouldBe false
+        }
+
+        "an unknown series id is not found" {
+            val f = ViewFixture()
+            every { f.seriesRepo.getById(VIEW_SERIES_ID) } returns null
+
+            shouldThrow<NoSuchElementException> { f.service.getSeriesWithGames(VIEW_SERIES_ID) }
+        }
+    })


### PR DESCRIPTION
Closes #200. Stacked on #214 (issue #199) — review that first.

`SeriesRoutes` had no read route at all; the only way to see a series was through its parent event. This adds the status view a client renders from, and the read any staleness nag depends on.

`GET /api/v1/series/{seriesId}` → `SeriesWithGamesDto`: every `SeriesDto` field, plus `tournamentCodes`, `games`, `lastCodeIssuedAt` and `lastGameAt`.

## Why the two collections matter

Codes issued is `tournamentCodes.length`, games played is `games.length`, and **they differ exactly when a code was issued and never played**. That difference is the whole reason #194 split the tables, and it's what lets a client warn *"game 2 hasn't been reported — report it, or continue anyway"* without Denny's ever gating code generation.

#189 rules that gate out explicitly: it would break TC11 (sides swapped, must regenerate immediately) and TC4 (bum code, replacement blocked), and wouldn't even stop TC8, where two simultaneous presses both pass the check. Exposing the numbers and letting the client decide is the alternative.

## Shape

Follows the established `XWithY` aggregate pattern (`EventWithSeries`, `TeamWithPlayers`) — a `SeriesWithGames` domain model built by `Series.toSeriesWithGames`, mapped to a DTO at the edge. No new repository methods; it composes `codeRepo.getBySeriesId` and `gameRepo.getBySeriesId`.

`lastCodeIssuedAt` and `lastGameAt` are derived on the aggregate as the **max `createdAt`** of each collection, not the last element:

```kotlin
val lastCodeIssuedAt: Instant? get() = tournamentCodes.maxOfOrNull { it.createdAt }
val lastGameAt: Instant? get() = games.maxOfOrNull { it.createdAt }
```

Taking the last element would silently couple these to repository ordering — `getBySeriesId` orders codes by id and games by number, both of which *usually* agree with time but neither of which promises to. Since a client uses these two timestamps to decide whether to nag a human, getting them from ordering would be a quiet source of wrong pings.

`reopenedAt` is carried here too, matching the field added to `SeriesDto` in #199.

## Testing

8 unit tests, one per acceptance criterion, including the bum-code case (2 codes, 1 game) and the codeless game still counting as played.

| Mutation | Killed by |
|---|---|
| `lastCodeIssuedAt` takes the first code, not the newest | `returns both collections and both timestamps` |
| `lastGameAt` takes the oldest game | `returns both collections and both timestamps` |

There's a dedicated test — `lastCodeIssuedAt reflects the newest code even when it is not last in the list` — that feeds the codes in reverse order, so the max-vs-ordering distinction is pinned independently rather than relying on the fixture happening to be sorted.

No new integration tests: this endpoint adds no SQL, and the DB-level property it depends on (issuing two codes creates two `tournament_codes` rows and zero `games` rows) is already covered in `TournamentCodeRepositoryTest`.

`assemble`, `test` (135 tests) and `itest` (66 tests) all pass locally.
