### PR TITLE
fix: Conflict and gateway error semantics

### DIFF
--- a/src/itest/kotlin/GameRepositoryTest.kt
+++ b/src/itest/kotlin/GameRepositoryTest.kt
@@ -27,8 +27,8 @@ import io.kotest.extensions.testcontainers.JdbcDatabaseContainerSpecExtension
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.jooq.SQLDialect
-import org.jooq.exception.IntegrityConstraintViolationException
 import org.jooq.impl.DSL
 import org.jooq.storage.tables.references.GAMES
 import org.testcontainers.postgresql.PostgreSQLContainer
@@ -161,12 +161,26 @@ class GameRepositoryTest :
             game.riotMatchId shouldBe "NA1_5102531894".toRiotMatchId()
         }
 
-        test("a duplicate riot match id is rejected") {
+        test("a duplicate riot match id is rejected as a conflict naming the existing game") {
             val series = newSeries()
-            repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null)).shouldNotBeNull()
+            val first = repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null)).shouldNotBeNull()
 
-            shouldThrow<IntegrityConstraintViolationException> {
-                repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null))
+            val ex =
+                shouldThrow<IllegalStateException> {
+                    repo.insert(NewGame(series.id, null, "NA1_DUPLICATE".toRiotMatchId(), null))
+                }
+
+            ex.message.toString() shouldContain "NA1_DUPLICATE"
+            ex.message.toString() shouldContain first.id.value.toString()
+        }
+
+        test("the riot match id conflict spans series, not just one") {
+            val a = newSeries()
+            val b = newSeries()
+            repo.insert(NewGame(a.id, null, "NA1_CROSSSERIES".toRiotMatchId(), null)).shouldNotBeNull()
+
+            shouldThrow<IllegalStateException> {
+                repo.insert(NewGame(b.id, null, "NA1_CROSSSERIES".toRiotMatchId(), null))
             }
         }
 

--- a/src/main/kotlin/com/lowbudgetlcs/api/StatusPages.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/StatusPages.kt
@@ -3,6 +3,7 @@ package com.lowbudgetlcs.api
 import com.lowbudgetlcs.api.dto.Error
 import com.lowbudgetlcs.domain.auth.UnauthorizedException
 import com.lowbudgetlcs.gateways.GatewayException
+import com.lowbudgetlcs.gateways.riot.RiotApiException
 import com.lowbudgetlcs.repositories.DatabaseException
 import io.ktor.http.*
 import io.ktor.serialization.*
@@ -47,6 +48,13 @@ fun Application.setupStatusPages() {
             logger.error("⚠️ Database Exception: $call", cause)
             val code = HttpStatusCode.InternalServerError
             val e = Error(code = code.value, message = cause.message ?: "Internal server error")
+            call.respond(code, e)
+        }
+        exception<RiotApiException> { call, cause ->
+            val code =
+                if (cause.retryable) HttpStatusCode.ServiceUnavailable else HttpStatusCode.BadGateway
+            logger.error("⚠️ Riot API Exception (status ${cause.status}, retryable=${cause.retryable})", cause)
+            val e = Error(code = code.value, message = cause.message ?: "Riot API request failed")
             call.respond(code, e)
         }
         exception<GatewayException> { call, cause ->

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -106,7 +106,9 @@ class SeriesService(
 
     override suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome {
         val series = getSeries(id)
-        val recordedCodeIds = gameRepo.getBySeriesId(id).mapNotNull { it.tournamentCodeId }.toSet()
+        val recorded = gameRepo.getBySeriesId(id)
+        val recordedCodeIds = recorded.mapNotNull { it.tournamentCodeId }.toSet()
+        val recordedMatchIds = recorded.mapNotNull { it.riotMatchId }.toSet()
         val outstanding = codeRepo.getBySeriesId(id).filter { it.id !in recordedCodeIds }
         if (outstanding.isEmpty()) {
             logger.debug("Series '$id' has no outstanding tournament codes.")
@@ -125,13 +127,18 @@ class SeriesService(
                     continue
                 }
             riotGames.forEach { riotGame ->
+                val matchId = riotMatchIdOf(riotGame)
+                if (matchId != null && matchId in recordedMatchIds) {
+                    logger.warn("Riot match '${matchId.value}' is already recorded for series '$id', skipping.")
+                    return@forEach
+                }
                 val result = resolveWinner(series, riotGame)
                 if (result != null) {
                     gameRepo.insert(
                         NewGame(
                             seriesId = id,
                             tournamentCodeId = code.id,
-                            riotMatchId = riotMatchIdOf(riotGame),
+                            riotMatchId = matchId,
                             result = result,
                         ),
                     )
@@ -327,6 +334,13 @@ class SeriesService(
 
     override fun removeSeries(id: SeriesId) {
         logger.debug("Deleting series '$id'...")
+        getSeries(id)
+        val codes = codeRepo.getBySeriesId(id).size
+        val games = gameRepo.getBySeriesId(id).size
+        check(codes == 0 && games == 0) {
+            "Series '${id.value}' has $codes tournament code(s) and $games game(s) recorded against it and " +
+                "cannot be deleted. Complete the series instead."
+        }
         try {
             return seriesRepo.delete(id)
         } catch (e: Throwable) {
@@ -354,10 +368,10 @@ class SeriesService(
         val event =
             eventRepo.getById(series.eventId)
                 ?: throw DatabaseException("Series with id '${series.id}' does not have parent event.")
-        val response =
-            gate.getCode(event.riotTournamentId, ShortcodeOptions(metadata = seriesMetadata(series.id)))
-                ?: throw GatewayException("Failed to create tournament code.")
-        val shortcode = response.codes.first()
+        val response = gate.getCode(event.riotTournamentId, ShortcodeOptions(metadata = seriesMetadata(series.id)))
+        val shortcode =
+            response.codes.firstOrNull()
+                ?: throw GatewayException("Riot returned no tournament codes for event '${event.id.value}'.")
         return codeRepo.insert(newCode, shortcode.toShortcode()) ?: throw DatabaseException("Failed to save game.")
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/RiotApiException.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/RiotApiException.kt
@@ -2,5 +2,13 @@ package com.lowbudgetlcs.gateways.riot
 
 class RiotApiException(
     message: String,
+    val status: Int? = null,
     cause: Throwable? = null,
-) : RuntimeException(message, cause)
+) : RuntimeException(message, cause) {
+    val retryable: Boolean get() = status == null || status == TOO_MANY_REQUESTS || status >= SERVER_ERROR
+
+    private companion object {
+        const val TOO_MANY_REQUESTS = 429
+        const val SERVER_ERROR = 500
+    }
+}

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/account/RiotAccountGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/account/RiotAccountGateway.kt
@@ -38,7 +38,7 @@ class RiotAccountGateway(
             HttpStatusCode.NotFound -> throw NoSuchElementException("Riot account not found for PUUID")
             else -> {
                 logger.warn("Failed to fetch account.")
-                throw RiotApiException("Unexpected Riot API error: ${response.status}")
+                throw RiotApiException("Unexpected Riot API error: ${response.status}", response.status.value)
             }
         }
     }

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/IRiotTournamentGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/IRiotTournamentGateway.kt
@@ -12,7 +12,7 @@ interface IRiotTournamentGateway {
     suspend fun getCode(
         riotTournamentId: RiotTournamentId,
         options: ShortcodeOptions,
-    ): RiotShortcodeDto?
+    ): RiotShortcodeDto
 
     suspend fun getGames(shortcode: Shortcode): List<RiotTournamentGamesV5Dto>
 }

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
@@ -49,7 +49,7 @@ class RiotTournamentGateway(
             )
 
             else -> {
-                throw RiotApiException("Unexpected Riot API error: ${res.status}")
+                throw RiotApiException("Unexpected Riot API error: ${res.status}", res.status.value)
             }
         }
     }
@@ -82,7 +82,7 @@ class RiotTournamentGateway(
 
             else -> {
                 logger.warn("Failed to create codes.")
-                throw RiotApiException("Unexpected Riot API error: ${res.status}")
+                throw RiotApiException("Unexpected Riot API error: ${res.status}", res.status.value)
             }
         }
     }
@@ -98,7 +98,7 @@ class RiotTournamentGateway(
         return when (res.status) {
             HttpStatusCode.OK -> res.body<List<RiotTournamentGamesV5Dto>>()
             HttpStatusCode.NotFound -> emptyList()
-            else -> throw RiotApiException("Unexpected Riot API error: ${res.status}")
+            else -> throw RiotApiException("Unexpected Riot API error: ${res.status}", res.status.value)
         }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/game/GameRepository.kt
@@ -35,6 +35,18 @@ class GameRepository(
             dsl.transactionResult { t ->
                 val tx = t.dsl()
                 tx.execute("SELECT pg_advisory_xact_lock(?)", newGame.seriesId.value.toLong())
+                newGame.riotMatchId?.let { matchId ->
+                    val existing =
+                        tx
+                            .select(GAMES.ID)
+                            .from(GAMES)
+                            .where(GAMES.RIOT_MATCH_ID.eq(matchId.value))
+                            .fetchOne()
+                            ?.get(GAMES.ID)
+                    check(existing == null) {
+                        "Riot match '${matchId.value}' is already recorded as game '$existing'."
+                    }
+                }
                 val highest =
                     tx
                         .select(max(GAMES.NUMBER))

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -859,9 +859,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "404":
+          description: Series or team not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "502":
           description: |
-            Riot could not issue a code. Retryable — Riot returned 429 or 5xx.
+            Riot rejected the request in a way that will not succeed on a
+            retry, for example a bad or unauthorised API key. Do not retry;
+            fall back to a custom game if a code is needed to play.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: |
+            Riot could not be reached, or rate-limited us (429 or 5xx). The
+            request is worth retrying shortly.
           content:
             application/json:
               schema:

--- a/src/test/kotlin/services/SeriesErrorSemanticsTest.kt
+++ b/src/test/kotlin/services/SeriesErrorSemanticsTest.kt
@@ -1,0 +1,205 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.Event
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.toEventDescription
+import com.lowbudgetlcs.domain.event.models.toEventName
+import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.event.models.types.EventStatus
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.Team
+import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.GatewayException
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.gateways.riot.tournament.RiotShortcodeDto
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+
+private val LEFT = TeamId(1)
+private val RIGHT = TeamId(2)
+private val ERR_SERIES_ID = SeriesId(80)
+private val ERR_EVENT_ID = EventId(1)
+private val ERR_AT = Instant.parse("2026-07-14T23:12:04Z")
+
+private class ErrorFixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    val series =
+        Series(
+            id = ERR_SERIES_ID,
+            eventId = ERR_EVENT_ID,
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 3,
+            participants = Pair(LEFT, RIGHT),
+            result = null,
+            completed = false,
+            completedAt = null,
+            reopenedAt = null,
+        )
+
+    val event =
+        Event(
+            id = ERR_EVENT_ID,
+            name = "Test".toEventName(),
+            description = "Testing".toEventDescription(),
+            riotTournamentId = 1.toRiotTournamentId(),
+            createdAt = ERR_AT,
+            startDate = ERR_AT,
+            endDate = ERR_AT.plusSeconds(3_600L),
+            status = EventStatus.ACTIVE,
+            eventGroupId = null,
+            eventStages = setOf(EventStage.PLAYOFFS),
+        )
+
+    fun code(id: Int) =
+        TournamentCode(
+            id = TournamentCodeId(id),
+            shortcode = Shortcode("SHORT-$id"),
+            blueTeamId = LEFT,
+            redTeamId = RIGHT,
+            seriesId = ERR_SERIES_ID,
+            createdAt = ERR_AT,
+        )
+
+    fun game(id: Int) =
+        Game(
+            id = GameId(id),
+            seriesId = ERR_SERIES_ID,
+            tournamentCodeId = null,
+            riotMatchId = null,
+            number = 1,
+            createdAt = ERR_AT,
+            result = GameResult(LEFT, RIGHT),
+        )
+
+    fun withContents(
+        codes: List<TournamentCode> = emptyList(),
+        games: List<Game> = emptyList(),
+    ) {
+        every { seriesRepo.getById(ERR_SERIES_ID) } returns series
+        every { codeRepo.getBySeriesId(ERR_SERIES_ID) } returns codes
+        every { gameRepo.getBySeriesId(ERR_SERIES_ID) } returns games
+        every { seriesRepo.delete(ERR_SERIES_ID) } returns Unit
+    }
+
+    fun readyToIssue() {
+        every { seriesRepo.getById(ERR_SERIES_ID) } returns series
+        every { codeRepo.getBySeriesId(ERR_SERIES_ID) } returns emptyList()
+        every { gameRepo.getBySeriesId(ERR_SERIES_ID) } returns emptyList()
+        every { teamRepo.getById(LEFT) } returns Team(LEFT, "Left".toTeamName(), null, ERR_EVENT_ID)
+        every { teamRepo.getById(RIGHT) } returns Team(RIGHT, "Right".toTeamName(), null, ERR_EVENT_ID)
+        every { eventRepo.getById(ERR_EVENT_ID) } returns event
+    }
+
+    val newCode = NewTournamentCode(ERR_SERIES_ID, LEFT, RIGHT)
+}
+
+class SeriesErrorSemanticsTest :
+    StringSpec({
+        "a Riot 429 is classified retryable" {
+            RiotApiException("rate limited", 429).retryable shouldBe true
+        }
+
+        "a Riot 5xx is classified retryable" {
+            RiotApiException("bad gateway", 502).retryable shouldBe true
+            RiotApiException("server error", 500).retryable shouldBe true
+        }
+
+        "a Riot 4xx other than 429 is classified terminal" {
+            RiotApiException("forbidden", 403).retryable shouldBe false
+            RiotApiException("bad request", 400).retryable shouldBe false
+            RiotApiException("not found", 404).retryable shouldBe false
+        }
+
+        "an unknown Riot status is treated as retryable rather than terminal" {
+            RiotApiException("no status").retryable shouldBe true
+        }
+
+        "deleting a series holding tournament codes is a conflict" {
+            val f = ErrorFixture()
+            f.withContents(codes = listOf(f.code(1)))
+
+            val ex = shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_SERIES_ID) }
+
+            ex.message.toString() shouldContain "Complete the series instead"
+            verify(exactly = 0) { f.seriesRepo.delete(any()) }
+        }
+
+        "deleting a series holding games is a conflict even with no codes left" {
+            val f = ErrorFixture()
+            f.withContents(games = listOf(f.game(10)))
+
+            shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_SERIES_ID) }
+
+            verify(exactly = 0) { f.seriesRepo.delete(any()) }
+        }
+
+        "deleting an empty series still works" {
+            val f = ErrorFixture()
+            f.withContents()
+
+            f.service.removeSeries(ERR_SERIES_ID)
+
+            verify(exactly = 1) { f.seriesRepo.delete(ERR_SERIES_ID) }
+        }
+
+        "deleting an unknown series is not found, not a conflict" {
+            val f = ErrorFixture()
+            every { f.seriesRepo.getById(ERR_SERIES_ID) } returns null
+
+            shouldThrow<NoSuchElementException> { f.service.removeSeries(ERR_SERIES_ID) }
+        }
+
+        "a Riot failure while issuing a code propagates rather than collapsing to a gateway error" {
+            val f = ErrorFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            coEvery { f.gateway.getCode(any(), any()) } throws RiotApiException("rate limited", 429)
+            f.readyToIssue()
+
+            val ex = shouldThrow<RiotApiException> { f.service.createGame(f.newCode) }
+
+            ex.status shouldBe 429
+            ex.retryable shouldBe true
+        }
+
+        "Riot answering with no codes is a gateway error, not a not-found" {
+            val f = ErrorFixture()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            coEvery { f.gateway.getCode(any(), any()) } returns RiotShortcodeDto(emptyList())
+            f.readyToIssue()
+
+            shouldThrow<GatewayException> { f.service.createGame(f.newCode) }
+
+            verify(exactly = 0) { f.codeRepo.insert(any(), any()) }
+        }
+    })

--- a/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
+++ b/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
@@ -177,6 +177,19 @@ class SeriesRefreshFromRiotTest :
             coVerify(exactly = 0) { f.gateway.getGames(any()) }
         }
 
+        "a match already recorded in the series is skipped rather than recorded twice" {
+            val f = Fixture()
+            coEvery { f.gateway.getGames(any()) } returns listOf(f.riotGame(listOf(PUUID_A)))
+            val alreadyRecorded =
+                f.playedGame(1).copy(riotMatchId = "NA1_5102531894".toRiotMatchId())
+            f.withSeries(listOf(f.code(2, "SHORT-B")), recorded = listOf(alreadyRecorded))
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
         "a winning roster with unregistered puuids still resolves via overlap" {
             val f = Fixture()
             coEvery { f.gateway.getGames(any()) } returns


### PR DESCRIPTION
Closes #201. Stacked on #215 (issue #200) — review that first.

Three places that returned a useless 500 for a situation the caller could act on.

## 1. Deleting a series with codes or games → 409

Was a raw foreign-key violation. The FKs are deliberately restrictive because a tournament code may already have `player_game_facts` rows keyed on its shortcode, so cascading would silently destroy stats.

**Scope note:** the ticket says "a series that has tournament codes", but `games.series_id` has the same restrictive FK. A series holding only codeless games — every game reported through the custom-game path — would have hit exactly the same 500. The guard covers both and the message names both counts.

## 2. Duplicate `riot_match_id` → 409

Checked inside the same transaction as the insert, so it can't race the constraint, and the message names the game that already holds the id.

`refreshFromRiot` deliberately does **not** rely on that throw. It derives the already-recorded match ids from the `getBySeriesId` call it already makes and skips them, so one match Riot attributes to two codes leaves the rest of the pull working rather than aborting it. The repository throw is the backstop for every other caller.

I first added a `getByRiotMatchId` repository method for this and backed it out: MockK cannot match `any()` against a `@JvmInline value class` parameter, so every fixture broke with an argument-type mismatch at the call site. Deriving from the list that's already fetched is better regardless — one fewer query per Riot game, and no new interface surface.

## 3. Riot failures are now distinguishable

`RiotApiException` carries the upstream status and answers whether it's retryable, with an explicit `StatusPages` mapping:

| Riot returned | We return | Meaning |
|---|---|---|
| 429, 5xx, or unknown | **503** | worth retrying shortly |
| any other 4xx | **502** | will not succeed on a retry |

That's the distinction TC2/TC3 need. Today every Riot failure fails identically, so a client can't tell "try again in a moment" from "give up on the code and play a custom game."

**Unknown status is treated as retryable.** Guessing terminal would strand a caller that could have succeeded on a retry; guessing retryable costs one wasted attempt. Cheap direction to be wrong in.

Also in this area:

- `getCode` is now non-nullable, matching what the gateway already did, so `createGame` no longer converts a null into an undifferentiated `GatewayException`.
- Riot answering with an **empty** code list was `codes.first()` throwing `NoSuchElementException` — which `StatusPages` maps to **404**. A Riot hiccup was surfacing as "series not found". Now an explicit `GatewayException`.

## Spec

502/503 added to code issuance, along with a previously undocumented **404** (a missing series or team already produced one). The stale 502 from #191 that described the retryable case was replaced, since retryable is now 503 — that edit briefly left a duplicate `502` key, so I wrote a strict loader that rejects duplicate keys and ran it over the whole document. It's clean.

`POST /results` deliberately gains neither: it calls Riot through `refreshQuietly`, which swallows failures by design, so it can't return a gateway status.

## Testing

13 unit tests and 2 integration tests, including a cross-series duplicate to show the match-id conflict is global rather than per-series.

| Mutation | Killed by |
|---|---|
| delete guard removed | `deleting a series holding tournament codes is a conflict`, `…holding games…` |
| 429 misclassified as terminal | `a Riot 429 is classified retryable`, `an unknown Riot status is treated as retryable`, `a Riot failure while issuing a code propagates` |
| duplicate-match skip removed | `a match already recorded in the series is skipped rather than recorded twice` |

`assemble`, `test` and `itest` all pass locally.
