### PR TITLE
feat: Implement Riot post-match callback

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,4 +147,6 @@ dependencies {
     testImplementation(libs.bundles.ktor.client.plugins)
     testImplementation(libs.ktor.serialization.json)
     testImplementation(libs.ktor.client.mock)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.bundles.ktor.server.plugins)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 # ktor-client plugins
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
+ktor-server-test-host = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
 # jooq
 jooq-core = { group = "org.jooq", name = "jooq", version.ref = "jooq" }
 jooq-meta = { group = "org.jooq", name = "jooq-meta", version.ref = "jooq" }

--- a/src/main/kotlin/com/lowbudgetlcs/api/Root.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/Root.kt
@@ -1,30 +1,20 @@
 package com.lowbudgetlcs.api
 
-import com.lowbudgetlcs.api.dto.auth.UserSession
-import com.lowbudgetlcs.api.dto.riot.PostMatchDto
 import com.lowbudgetlcs.api.routes.apiRoutes
 import com.lowbudgetlcs.api.routes.authRoutes
-import com.lowbudgetlcs.config.CookieConfig
-import com.lowbudgetlcs.domain.auth.IAuthService
-import com.lowbudgetlcs.domain.user.IUserService
-import io.ktor.http.HttpStatusCode
+import com.lowbudgetlcs.api.routes.riotCallbackRoutes
+import com.lowbudgetlcs.domain.series.ISeriesService
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.http.content.singlePageApplication
 import io.ktor.server.http.content.vue
 import io.ktor.server.plugins.autohead.AutoHeadResponse
 import io.ktor.server.plugins.swagger.swaggerUI
-import io.ktor.server.request.receive
 import io.ktor.server.resources.Resources
-import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
-import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import io.ktor.server.sessions.Sessions
-import io.ktor.server.sessions.cookie
-import io.ktor.server.sessions.sameSite
 import org.koin.ktor.ext.inject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -32,6 +22,7 @@ import org.slf4j.LoggerFactory
 val logger: Logger = LoggerFactory.getLogger(Application::class.java)
 
 fun Application.routes() {
+    val seriesService by inject<ISeriesService>()
 
     routing {
         setupLogging()
@@ -54,13 +45,7 @@ fun Application.routes() {
                 call.respondText("OK")
             }
         }
-        route("/riot-callback") {
-            post {
-                val dto = call.receive<PostMatchDto>()
-                logger.debug(dto.toString())
-                call.respond(HttpStatusCode.OK)
-            }
-        }
+        riotCallbackRoutes(seriesService)
         authRoutes()
         apiRoutes()
     }

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/RiotCallbackRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/RiotCallbackRoutes.kt
@@ -1,0 +1,29 @@
+package com.lowbudgetlcs.api.routes
+
+import com.lowbudgetlcs.api.dto.riot.PostMatchDto
+import com.lowbudgetlcs.domain.event.models.toShortcode
+import com.lowbudgetlcs.domain.series.ISeriesService
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(Application::class.java)
+
+private val riotCallbackJson = Json { ignoreUnknownKeys = true }
+
+fun Route.riotCallbackRoutes(seriesService: ISeriesService) {
+    route("/riot-callback") {
+        post {
+            val dto = riotCallbackJson.decodeFromString<PostMatchDto>(call.receiveText())
+            logger.debug(dto.toString())
+            seriesService.refreshFromShortcode(dto.shortCode.toShortcode())
+            call.respond(HttpStatusCode.OK)
+        }
+    }
+}

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -1,5 +1,6 @@
 package com.lowbudgetlcs.domain.series
 
+import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
@@ -46,6 +47,8 @@ interface ISeriesService {
     fun evaluateCompletion(id: SeriesId): Series
 
     suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome
+
+    suspend fun refreshFromShortcode(shortcode: Shortcode): RefreshOutcome?
 
     suspend fun reportResult(
         id: SeriesId,

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -39,6 +39,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
+private const val RELAY_METADATA_TAG = "LBLCS"
+
 class SeriesService(
     private val codeRepo: ITournamentCodeRepository,
     private val seriesRepo: ISeriesRepository,
@@ -296,7 +298,16 @@ class SeriesService(
         }
     }
 
-    private fun seriesMetadata(id: SeriesId): String = """{"seriesId":${id.value}}"""
+    override suspend fun refreshFromShortcode(shortcode: Shortcode): RefreshOutcome? {
+        val code = codeRepo.getByShortcode(shortcode)
+        if (code == null) {
+            logger.warn("Callback for unknown shortcode '${shortcode.value}', ignoring.")
+            return null
+        }
+        return refreshFromRiot(code.seriesId)
+    }
+
+    private fun seriesMetadata(id: SeriesId): String = """{"tag":"$RELAY_METADATA_TAG","seriesId":${id.value}}"""
 
     private fun riotMatchIdOf(riotGame: RiotTournamentGamesV5Dto): RiotMatchId? {
         val platformId = RiotRegion.platformIdOf(riotGame.region)

--- a/src/test/kotlin/routes/RiotCallbackRouteTest.kt
+++ b/src/test/kotlin/routes/RiotCallbackRouteTest.kt
@@ -1,0 +1,97 @@
+package routes
+
+import com.lowbudgetlcs.api.routes.riotCallbackRoutes
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.series.ISeriesService
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+
+private const val ROUTE_SHORTCODE = "NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae"
+
+/** The body relay forwards byte-for-byte from Riot, per lowbudgetlcs/relay main.go RiotPayload. */
+private fun relayPayload(extra: String = "") =
+    """
+    {
+      "startTime": 1752534724000,
+      "shortCode": "$ROUTE_SHORTCODE",
+      "metaData": "{\"tag\":\"LBLCS\",\"seriesId\":90}",
+      "gameId": 5102531894,
+      "gameName": "cb0b0b1e-0000-0000-0000-000000000000",
+      "gameType": "Practice",
+      "gameMap": 11,
+      "gameMode": "CLASSIC",
+      "region": "NA1"$extra
+    }
+    """.trimIndent()
+
+class RiotCallbackRouteTest :
+    StringSpec({
+        "a relay-forwarded callback reaches the service with the shortcode Riot named" {
+            val service = mockk<ISeriesService>(relaxed = false)
+            val shortcode = slot<Shortcode>()
+            coEvery { service.refreshFromShortcode(capture(shortcode)) } returns RefreshOutcome.ATTRIBUTED
+
+            testApplication {
+                application { routing { riotCallbackRoutes(service) } }
+
+                val response: HttpResponse =
+                    client.post("/riot-callback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(relayPayload())
+                    }
+
+                response.status shouldBe HttpStatusCode.OK
+            }
+
+            shortcode.captured shouldBe Shortcode(ROUTE_SHORTCODE)
+        }
+
+        "a field Riot adds later does not reject the callback" {
+            val service = mockk<ISeriesService>(relaxed = false)
+            coEvery { service.refreshFromShortcode(any()) } returns RefreshOutcome.ATTRIBUTED
+
+            testApplication {
+                application { routing { riotCallbackRoutes(service) } }
+
+                val response: HttpResponse =
+                    client.post("/riot-callback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(relayPayload(extra = ""","somethingRiotAddedLater": "value""""))
+                    }
+
+                response.status shouldBe HttpStatusCode.OK
+            }
+
+            coVerify(exactly = 1) { service.refreshFromShortcode(Shortcode(ROUTE_SHORTCODE)) }
+        }
+
+        "an unknown shortcode is still answered with 200 so Riot does not retry" {
+            val service = mockk<ISeriesService>(relaxed = false)
+            coEvery { service.refreshFromShortcode(any()) } returns null
+
+            testApplication {
+                application { routing { riotCallbackRoutes(service) } }
+
+                val response: HttpResponse =
+                    client.post("/riot-callback") {
+                        contentType(ContentType.Application.Json)
+                        setBody(relayPayload())
+                    }
+
+                response.status shouldBe HttpStatusCode.OK
+            }
+        }
+    })

--- a/src/test/kotlin/services/RiotCallbackTest.kt
+++ b/src/test/kotlin/services/RiotCallbackTest.kt
@@ -1,0 +1,273 @@
+package services
+
+import com.lowbudgetlcs.api.dto.riot.PostMatchDto
+import com.lowbudgetlcs.domain.event.models.Event
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.ShortcodeOptions
+import com.lowbudgetlcs.domain.event.models.toEventDescription
+import com.lowbudgetlcs.domain.event.models.toEventName
+import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.event.models.types.EventStatus
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewGame
+import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.toRiotMatchId
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
+import com.lowbudgetlcs.domain.series.models.ReportedResult
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.Team
+import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.gateways.riot.tournament.RiotShortcodeDto
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentGamesV5Dto
+import com.lowbudgetlcs.gateways.riot.tournament.RiotTournamentTeamV5Dto
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.time.Instant
+
+private val CB_BLUE = TeamId(1)
+private val CB_RED = TeamId(2)
+private val CB_SERIES_ID = SeriesId(90)
+private val CB_EVENT_ID = EventId(1)
+private val CB_AT = Instant.parse("2026-07-14T23:12:04Z")
+
+private const val CB_PUUID = "aa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+private const val CB_SHORTCODE = "NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae"
+
+/** The body relay forwards byte-for-byte from Riot, per lowbudgetlcs/relay main.go RiotPayload. */
+private const val RELAY_PAYLOAD = """
+{
+  "startTime": 1752534724000,
+  "shortCode": "$CB_SHORTCODE",
+  "metaData": "{\"tag\":\"LBLCS\",\"seriesId\":90}",
+  "gameId": 5102531894,
+  "gameName": "cb0b0b1e-0000-0000-0000-000000000000",
+  "gameType": "Practice",
+  "gameMap": 11,
+  "gameMode": "CLASSIC",
+  "region": "NA1"
+}
+"""
+
+private val callbackJson = Json { ignoreUnknownKeys = true }
+
+private class CallbackFixture {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway)
+
+    val games = mutableListOf<Game>()
+    private var nextId = 200
+
+    val code =
+        TournamentCode(
+            id = TournamentCodeId(1),
+            shortcode = Shortcode(CB_SHORTCODE),
+            blueTeamId = CB_BLUE,
+            redTeamId = CB_RED,
+            seriesId = CB_SERIES_ID,
+            createdAt = CB_AT,
+        )
+
+    val event =
+        Event(
+            id = CB_EVENT_ID,
+            name = "Test".toEventName(),
+            description = "Testing".toEventDescription(),
+            riotTournamentId = 1.toRiotTournamentId(),
+            createdAt = CB_AT,
+            startDate = CB_AT,
+            endDate = CB_AT.plusSeconds(3_600L),
+            status = EventStatus.ACTIVE,
+            eventGroupId = null,
+            eventStages = setOf(EventStage.PLAYOFFS),
+        )
+
+    fun series(completed: Boolean = false) =
+        Series(
+            id = CB_SERIES_ID,
+            eventId = CB_EVENT_ID,
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 3,
+            participants = Pair(CB_BLUE, CB_RED),
+            result = null,
+            completed = completed,
+            completedAt = if (completed) CB_AT else null,
+            reopenedAt = null,
+        )
+
+    fun riotGame() =
+        RiotTournamentGamesV5Dto(
+            winningTeam = listOf(RiotTournamentTeamV5Dto(CB_PUUID)),
+            shortCode = CB_SHORTCODE,
+            gameId = 5102531894L,
+            region = "NA",
+        )
+
+    fun recordedGame(codeId: Int?) =
+        Game(
+            id = GameId(nextId++),
+            seriesId = CB_SERIES_ID,
+            tournamentCodeId = codeId?.let { TournamentCodeId(it) },
+            riotMatchId = "NA1_5102531894".toRiotMatchId(),
+            number = games.size + 1,
+            createdAt = CB_AT,
+            result = GameResult(CB_BLUE, CB_RED),
+        )
+
+    fun withSeries(
+        series: Series = series(),
+        recorded: List<Game> = emptyList(),
+    ) {
+        games.clear()
+        games += recorded
+        every { seriesRepo.getById(CB_SERIES_ID) } returns series
+        every { codeRepo.getByShortcode(Shortcode(CB_SHORTCODE)) } returns code
+        every { codeRepo.getBySeriesId(CB_SERIES_ID) } returns listOf(code)
+        every { gameRepo.getBySeriesId(CB_SERIES_ID) } answers { games.toList() }
+        every { teamRepo.getTeamIdsByPuuids(any()) } returns listOf(CB_BLUE)
+        every { seriesRepo.complete(any(), any(), any()) } returns series.copy(completed = true)
+        every { gameRepo.insert(any()) } answers {
+            val new = firstArg<NewGame>()
+            val game =
+                Game(
+                    id = GameId(nextId++),
+                    seriesId = new.seriesId,
+                    tournamentCodeId = new.tournamentCodeId,
+                    riotMatchId = new.riotMatchId,
+                    number = games.size + 1,
+                    createdAt = CB_AT,
+                    result = new.result,
+                )
+            games += game
+            game
+        }
+    }
+}
+
+class RiotCallbackTest :
+    StringSpec({
+        "the payload relay forwards deserializes into PostMatchDto unchanged" {
+            val dto = callbackJson.decodeFromString<PostMatchDto>(RELAY_PAYLOAD)
+
+            dto.shortCode shouldBe CB_SHORTCODE
+            dto.gameId shouldBe 5102531894L
+            dto.region shouldBe "NA1"
+            dto.gameMap shouldBe 11
+            dto.startTime shouldBe 1752534724000L
+        }
+
+        "the metadata Denny's stamps carries the tag relay requires to forward at all" {
+            val f = CallbackFixture()
+            val options = slot<ShortcodeOptions>()
+            coEvery { f.gateway.getGames(any()) } returns emptyList()
+            coEvery { f.gateway.getCode(any(), capture(options)) } returns RiotShortcodeDto(listOf(CB_SHORTCODE))
+            f.withSeries()
+            every { f.teamRepo.getById(CB_BLUE) } returns Team(CB_BLUE, "Blue".toTeamName(), null, CB_EVENT_ID)
+            every { f.teamRepo.getById(CB_RED) } returns Team(CB_RED, "Red".toTeamName(), null, CB_EVENT_ID)
+            every { f.eventRepo.getById(CB_EVENT_ID) } returns f.event
+            every { f.codeRepo.insert(any(), any()) } returns f.code
+
+            f.service.createGame(NewTournamentCode(CB_SERIES_ID, CB_BLUE, CB_RED))
+
+            val metadata = Json.parseToJsonElement(options.captured.metadata).jsonObject
+            metadata["tag"]?.jsonPrimitive?.content shouldBe "LBLCS"
+            metadata["seriesId"]?.jsonPrimitive?.content shouldBe "90"
+        }
+
+        "a callback records the game and its result" {
+            val f = CallbackFixture()
+            coEvery { f.gateway.getGames(Shortcode(CB_SHORTCODE)) } returns listOf(f.riotGame())
+            f.withSeries()
+
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE)) shouldBe RefreshOutcome.ATTRIBUTED
+
+            f.games.size shouldBe 1
+            f.games.single().tournamentCodeId shouldBe TournamentCodeId(1)
+            f.games.single().riotMatchId shouldBe "NA1_5102531894".toRiotMatchId()
+            f.games.single().result shouldBe GameResult(CB_BLUE, CB_RED)
+        }
+
+        "the same callback twice records one game" {
+            val f = CallbackFixture()
+            coEvery { f.gateway.getGames(Shortcode(CB_SHORTCODE)) } returns listOf(f.riotGame())
+            f.withSeries()
+
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE))
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE)) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            f.games.size shouldBe 1
+        }
+
+        "a report followed by the callback for that code records one game" {
+            val f = CallbackFixture()
+            coEvery { f.gateway.getGames(Shortcode(CB_SHORTCODE)) } returns listOf(f.riotGame())
+            f.withSeries(recorded = listOf(f.recordedGame(codeId = 1)))
+
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE)) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            f.games.size shouldBe 1
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "the callback followed by the same report records one game" {
+            val f = CallbackFixture()
+            coEvery { f.gateway.getGames(Shortcode(CB_SHORTCODE)) } returns listOf(f.riotGame())
+            f.withSeries()
+
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE))
+            val outcome = f.service.reportResult(CB_SERIES_ID, ReportedResult(null, null, null, null))
+
+            outcome.recorded shouldBe false
+            f.games.size shouldBe 1
+        }
+
+        "a late callback for a closed series records the game and leaves it closed" {
+            val f = CallbackFixture()
+            coEvery { f.gateway.getGames(Shortcode(CB_SHORTCODE)) } returns listOf(f.riotGame())
+            f.withSeries(series = f.series(completed = true))
+
+            f.service.refreshFromShortcode(Shortcode(CB_SHORTCODE)) shouldBe RefreshOutcome.ATTRIBUTED
+
+            f.games.size shouldBe 1
+            verify(exactly = 0) { f.seriesRepo.complete(any(), any(), any()) }
+        }
+
+        "a callback for an unknown shortcode writes nothing" {
+            val f = CallbackFixture()
+            every { f.codeRepo.getByShortcode(Shortcode("NOT-OURS")) } returns null
+
+            f.service.refreshFromShortcode(Shortcode("NOT-OURS")).shouldBeNull()
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+    })


### PR DESCRIPTION
Closes #202. Stacked on #216 (issue #201) — review that first.

`POST /riot-callback` resolves the `tournament_codes` row by `shortCode` and delegates to `refreshFromRiot`. The callback is a **trigger, not a parser**, so push and pull share one code path and cannot disagree about what a result means. `PostMatchDto` is unchanged, as the ticket insists.

Idempotency falls straight out of that delegation — `refreshFromRiot` already skips codes that have a game and match ids already recorded:

| Sequence | Result |
|---|---|
| same callback twice | one game |
| report, then callback for that code | one game |
| callback, then the same report | one game |
| late callback for a closed series | game recorded, **not** reopened (TC10) |
| unknown shortcode | logged, 200, nothing written |

## What checking relay turned up

The ticket said to confirm what relay actually forwards before touching the handler. It's at `lowbudgetlcs/relay`; `main.go` is a reverse proxy that validates and then forwards Riot's body byte-for-byte. Two findings.

### 1. A blocker: every callback would have been dropped before reaching us

Relay parses `metaData` and discards anything whose tag isn't `LBLCS`:

```go
if err := json.Unmarshal([]byte(payload.MetaData), &metadata); err != nil { → 422 }
if metadata.Tag != METADATA_TAG { → 422 }   // METADATA_TAG = "LBLCS"
```

We stamp `{"seriesId":N}` — no `tag` — so relay would have 422'd every callback and Denny's would never have seen one. **Implementing the handler alone would have shipped a dead endpoint.**

It's worse historically: before #197 `ShortcodeOptions.metadata` was `""`, and `json.Unmarshal("")` errors, so this endpoint has never received anything. That's consistent with #189's "nothing ever completes a series."

Metadata is now `{"tag":"LBLCS","seriesId":N}` — satisfies relay, keeps the `seriesId` cross-check.

### 2. A field Riot adds later would lose the game

`ContentNegotiation` is configured without `ignoreUnknownKeys`, so any new field in the callback body rejects the whole request. Relay wouldn't stop it — Go ignores unknown fields, so it forwards happily and we'd be the ones to fail.

The callback parses with **its own lenient `Json`** rather than loosening validation globally. This is the one route whose payload we don't control; everywhere else, strict parsing catching a client typo is a feature, and #201 just went to some trouble to make client errors legible.

## Structure

The route moved out of `Root.kt` into `RiotCallbackRoutes.kt`, matching `authRoutes`/`apiRoutes`. That's what lets the test drive the real endpoint through `testApplication` without standing up Koin and a database — the alternative was widening the parser's visibility purely for a test, which isn't a good trade. Needed `ktor-server-test-host`, the first route-level test harness in the repo.

`Root.kt` also loses seven unused imports that pre-date this change (it had nine; extracting the route cleared two).

## Testing

8 service tests and 3 route tests. The route tests exercise the real handler and the real parser config, not a copy of it.

| Mutation | Killed by |
|---|---|
| relay tag dropped from metadata | `the metadata Denny's stamps carries the tag relay requires to forward at all` |
| callback parsed strictly | `a field Riot adds later does not reject the callback` |
| callback ignores the shortcode Riot named | `a relay-forwarded callback reaches the service with the shortcode Riot named` |

The realistic payload used throughout is transcribed from relay's `RiotPayload` struct, including `"region": "NA1"` — the platformId form, which is the callback's asymmetry with `games/by-code`'s `"NA"`.

`assemble`, `test` (157 tests) and `itest` all pass locally.

## Still open

The endpoint stays unauthenticated and outside `/api/v1`, as relay requires. Anyone who can reach it can fabricate a game. #189 puts that out of scope and says it should be filed separately — it still hasn't been.
