### PR TITLE
fix: Log Riot games/by-code lookups that 404

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotTournamentGateway.kt
@@ -89,15 +89,19 @@ class RiotTournamentGateway(
 
     override suspend fun getGames(shortcode: Shortcode): List<RiotTournamentGamesV5Dto> {
         logger.debug("Fetching games for shortcode '${shortcode.value}'...")
+        val endpoint = "$url/games/by-code/${shortcode.value}"
         val res: HttpResponse =
-            client.get("$url/games/by-code/${shortcode.value}") {
+            client.get(endpoint) {
                 headers {
                     append("X-Riot-Token", apiKey)
                 }
             }
         return when (res.status) {
             HttpStatusCode.OK -> res.body<List<RiotTournamentGamesV5Dto>>()
-            HttpStatusCode.NotFound -> emptyList()
+            HttpStatusCode.NotFound -> {
+                logger.warn("Riot returned 404 for '$endpoint'; treating as no game played yet.")
+                emptyList()
+            }
             else -> throw RiotApiException("Unexpected Riot API error: ${res.status}", res.status.value)
         }
     }


### PR DESCRIPTION
Closes #220.

`getGames` mapped a 404 from `games/by-code` to `emptyList()` with no log. That is the right
answer for a series with no game played yet, but it is also the answer when the call is broken —
a revoked or wrong API key, a wrong region, Riot moving the path, or `useStubs` left on, since
tournament-stub-v5 has no `games/by-code` resource and 404s every time. The pull path then
degrades silently to self-serve reporting and nothing records that it stopped working.

Adds a WARN with the resolved URL. Behaviour is unchanged — still `emptyList()`.

The API key travels in the `X-Riot-Token` header, not the URL, so the logged endpoint carries no
secret.

## Why now

1.4.0 ships with TC5b, TC10, TC17 and TC18 verified against real play in production (#221) rather
than on staging, because staging's stub API cannot produce a game. That plan depends on being able
to read production logs and tell "no game played yet" from "the Riot call is failing" — which is
exactly the distinction this restores.

## Testing

`RiotTournamentGatewayTest` already covers the branch ("getGames treats 404 as Riot answering with
no game"); it still passes, which is the point — this is additive.
