### PR TITLE
fix: Scope series deletion to the event in the URL

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/event/EventRoutes.kt
@@ -92,7 +92,7 @@ fun Route.eventRoutesV1(
             call.respond(HttpStatusCode.Created, series.toDto())
         }
         delete<EventResources.ByIdSeriesId> { route ->
-            seriesService.removeSeries(route.seriesId.toSeriesId())
+            seriesService.removeSeries(route.eventId.toEventId(), route.seriesId.toSeriesId())
             val event = eventService.getEventWithSeries(route.eventId.toEventId())
             call.respond(event.toDto())
         }

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -66,14 +66,19 @@ interface ISeriesService {
     fun getSeriesWithGames(id: SeriesId): SeriesWithGames
 
     /**
-     * Remove a series.
+     * Remove a series belonging to an event.
      *
-     * @param SeriesId the target series.
+     * @param eventId the event the series must belong to.
+     * @param id the target series.
      *
-     * @throws NoSuchElementException if the specified event or team doesn't exist
+     * @throws NoSuchElementException if the series doesn't exist or isn't part of the event
+     * @throws IllegalStateException if the series has codes or games recorded against it
      * @throws com.lowbudgetlcs.repositories.DatabaseException if the delete operation fails
      */
-    fun removeSeries(id: SeriesId)
+    fun removeSeries(
+        eventId: EventId,
+        id: SeriesId,
+    )
 
     /**
      * Create a game inside of a series.

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -343,9 +343,15 @@ class SeriesService(
         return GameResult(winner, if (winner == first) second else first)
     }
 
-    override fun removeSeries(id: SeriesId) {
-        logger.debug("Deleting series '$id'...")
-        getSeries(id)
+    override fun removeSeries(
+        eventId: EventId,
+        id: SeriesId,
+    ) {
+        logger.debug("Deleting series '$id' from event '$eventId'...")
+        val series = getSeries(id)
+        if (series.eventId != eventId) {
+            throw NoSuchElementException("Series '${id.value}' is not part of event '${eventId.value}'.")
+        }
         val codes = codeRepo.getBySeriesId(id).size
         val games = gameRepo.getBySeriesId(id).size
         check(codes == 0 && games == 0) {

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -756,7 +756,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/EventWithSeriesDto"
         "404":
-          description: Event or series not found
+          description: |
+            Event not found, series not found, or the series is not part of
+            this event. A series may only be deleted through the event it
+            belongs to.
           content:
             application/json:
               schema:

--- a/src/test/kotlin/services/SeriesErrorSemanticsTest.kt
+++ b/src/test/kotlin/services/SeriesErrorSemanticsTest.kt
@@ -149,7 +149,7 @@ class SeriesErrorSemanticsTest :
             val f = ErrorFixture()
             f.withContents(codes = listOf(f.code(1)))
 
-            val ex = shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_SERIES_ID) }
+            val ex = shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_EVENT_ID, ERR_SERIES_ID) }
 
             ex.message.toString() shouldContain "Complete the series instead"
             verify(exactly = 0) { f.seriesRepo.delete(any()) }
@@ -159,7 +159,7 @@ class SeriesErrorSemanticsTest :
             val f = ErrorFixture()
             f.withContents(games = listOf(f.game(10)))
 
-            shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_SERIES_ID) }
+            shouldThrow<IllegalStateException> { f.service.removeSeries(ERR_EVENT_ID, ERR_SERIES_ID) }
 
             verify(exactly = 0) { f.seriesRepo.delete(any()) }
         }
@@ -168,7 +168,7 @@ class SeriesErrorSemanticsTest :
             val f = ErrorFixture()
             f.withContents()
 
-            f.service.removeSeries(ERR_SERIES_ID)
+            f.service.removeSeries(ERR_EVENT_ID, ERR_SERIES_ID)
 
             verify(exactly = 1) { f.seriesRepo.delete(ERR_SERIES_ID) }
         }
@@ -177,7 +177,20 @@ class SeriesErrorSemanticsTest :
             val f = ErrorFixture()
             every { f.seriesRepo.getById(ERR_SERIES_ID) } returns null
 
-            shouldThrow<NoSuchElementException> { f.service.removeSeries(ERR_SERIES_ID) }
+            shouldThrow<NoSuchElementException> { f.service.removeSeries(ERR_EVENT_ID, ERR_SERIES_ID) }
+        }
+
+        "a series cannot be deleted through another event's id" {
+            val f = ErrorFixture()
+            f.withContents()
+
+            val ex =
+                shouldThrow<NoSuchElementException> {
+                    f.service.removeSeries(EventId(ERR_EVENT_ID.value + 1), ERR_SERIES_ID)
+                }
+
+            ex.message.toString() shouldContain "is not part of event"
+            verify(exactly = 0) { f.seriesRepo.delete(any()) }
         }
 
         "a Riot failure while issuing a code propagates rather than collapsing to a gateway error" {


### PR DESCRIPTION
Closes #223.

`removeSeries` took only a series id, so `{eventId}` in
`DELETE /api/v1/event/{eventId}/series/{seriesId}` was decorative. A series belonging to one
event could be deleted through any other event's URL — and because the handler then responds with
`getEventWithSeries(route.eventId)`, the 200 rendered the *unrelated* event's unchanged list, so
the deletion was invisible in the very response confirming it.

Found while walking #203 on staging: series 782, created in event 9, was deleted via
`/api/v1/event/1/series/782` → 200 showing Season 15 LCS, then `GET /api/v1/series/782` → 404.

## Change

`ISeriesService.removeSeries` now takes both ids and 404s when they disagree:

```kotlin
val series = getSeries(id)
if (series.eventId != eventId) {
    throw NoSuchElementException("Series '${id.value}' is not part of event '${eventId.value}'.")
}
```

The check lives in the service rather than the route because the service owns the invariant — the
route was the only caller, but the interface no longer permits an unscoped delete.

404 rather than 403 or 409: from that URL's perspective the resource genuinely does not exist, and
it matches how the codebase already handles a code targeted from the wrong series
(`resolveTarget`, "does not belong to series").

Ordering is deliberate — not-found still beats the conflict check, so a nonexistent series is a
404 rather than a 409 about codes.

## Not a regression

`main` carries identical code, so this predates 1.4.0. 1.4.0 in fact narrowed the blast radius by
adding the 409 guard for series with codes or games (#201), which already blocked the destructive
cases; what remained reachable was deleting an *empty* series through the wrong event.

## Testing

New case in `SeriesErrorSemanticsTest`: *"a series cannot be deleted through another event's id"* —
asserts the 404 and that `seriesRepo.delete` is never reached. Mutation-verified by neutering the
guard, which fails that test and only that test. The four existing delete cases were updated for
the new signature and still pass; `test` and `itest` green.
