### PR TITLE
docs: Correct OpenAPI drift found in the 1.4.0 staging walk

### DIFF
--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -707,11 +707,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/SeriesDto"
         "400":
-          description: Request body is invalid.
+          description: The request body is not valid JSON.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: Event or team not found
           content:
@@ -727,6 +729,19 @@ paths:
 
             Note that repeat series between the same two teams are supported —
             two teams may legitimately meet more than once inside one stage.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "422":
+          description: |
+            Validation failed.
+
+            Possible reasons:
+            - `totalGames` is not greater than zero.
+            - `stage` is not a valid `EventStage`.
           content:
             application/json:
               schema:
@@ -755,6 +770,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventWithSeriesDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: Event or series not found
           content:
@@ -763,10 +780,10 @@ paths:
                 $ref: "#/components/schemas/Error"
         "409":
           description: |
-            The series has tournament codes issued against it and cannot be
-            deleted. A tournament code is a real Riot artifact and may already
-            have player stats keyed on its shortcode. Complete the series
-            instead.
+            The series has tournament codes or games recorded against it and
+            cannot be deleted. A tournament code is a real Riot artifact and
+            may already have player stats keyed on its shortcode. Complete the
+            series instead.
           content:
             application/json:
               schema:
@@ -882,6 +899,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          description: |
+            The series has no parent event, Riot returned an empty list of
+            codes, or the code could not be persisted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /api/v1/series/{seriesId}/results:
     post:
@@ -925,19 +954,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GameDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
-          description: Series or tournament code not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        "409":
           description: |
-            A game with this Riot match id is already recorded.
+            Series not found, the tournament code was not found, or the code
+            belongs to a different series.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
         "422":
           description: |
             Invalid combination of fields.
@@ -1546,6 +1574,23 @@ paths:
           description: Unexpected error
 
 components:
+  responses:
+    Unauthorized:
+      description: |
+        No valid session cookie or bearer token was supplied. Applies to every
+        operation under `/api/v1`.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    UnsupportedMediaType:
+      description: |
+        The request carried a body without `Content-Type: application/json`.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
   securitySchemes:
     cookieAuth:
       type: apiKey
@@ -1569,7 +1614,6 @@ components:
       enum:
         - REGULAR_SEASON
         - PLAYOFFS
-        - PROMOTION_RELEGATION
 
     # Auth Schemas
     LoginDto:


### PR DESCRIPTION
Closes #224.

Six places where `documentation.yaml` and the implementation disagreed, all found by walking #203
against staging. **The shipped behaviour is correct in every case — the spec was wrong**, so this
is documentation only and changes no runtime behaviour.

It matters because Stephen's client is generated from this spec (#189), so drift here propagates
into a consumer.

| Fix | Was | Now |
|---|---|---|
| `EventStage` | listed `PROMOTION_RELEGATION` | removed — the Kotlin enum has only `REGULAR_SEASON` and `PLAYOFFS`, and `?stage=PROMOTION_RELEGATION` 400s |
| `POST /event/{id}/series` | 400 for "request body is invalid" | 400 narrowed to malformed JSON; **422** documented for `totalGames <= 0` and an invalid `stage` |
| `POST /series/{id}/game` | 400/404/422/502/503 | adds **500** — the empty-codes `GatewayException` and two `DatabaseException` paths |
| `POST /series/{id}/results` | documented a 409 | **removed** — unreachable through this endpoint (see below); 404 now also covers a code belonging to another series |
| `DELETE /event/{id}/series/{id}` 409 | "has tournament codes" | "has tournament codes **or games**" — `removeSeries` conflicts on `codes != 0 \|\| games != 0` |
| 401 / 415 | undocumented | shared `Unauthorized` and `UnsupportedMediaType` responses under `components/responses`, referenced from the series operations |

## On the removed 409

The only source of that `IllegalStateException` is `GameRepository.insert`'s
`check(existing == null)`, which requires a non-null `riotMatchId`. `record()` always passes
`null`, and the Riot pull path runs inside `refreshQuietly`, which swallows every `Throwable`. So
nothing reachable from `POST /results` can produce it — only `/riot-callback` can. Documenting it
here told clients to handle a case that cannot occur.

## Verified

Each documented code was observed live on `dennys-140`, not inferred:

```
totalGames=0                              -> 422
?stage=PROMOTION_RELEGATION               -> 400
POST /results without Content-Type        -> 415
expired session                           -> 401
code belonging to another series          -> 404
DELETE series holding a code              -> 409
```

The document parses under a strict loader with duplicate-key detection, and every `$ref`
resolves, including the two new ones.

## Deliberately out of scope

Item 7 on the issue — `NewTeamDto.eventId` is accepted by `POST /api/v1/team` and silently
dropped, because the `NewTeam` domain model has no such property. That needs a decision (honour it
or remove it) rather than a doc edit, so it stays open on #224 after this merges.

A sweep adding the shared 401 response to the remaining non-series operations is also follow-up;
this PR covers the operations the 1.4.0 work touched.
