### PR TITLE
ci: Retry Flyway connection attempts

### DIFF
--- a/scripts/flyway.sh
+++ b/scripts/flyway.sh
@@ -32,6 +32,8 @@ flyway() {
     -executeInTransaction=false \
     -outOfOrder=false \
     -validateMigrationNaming=true \
+    -connectRetries=10 \
+    -connectRetriesInterval=5 \
     "$@"
 }
 


### PR DESCRIPTION
Observed while baselining production: the pooler host failed to resolve, then resolved unchanged moments later. `aws-0-us-east-1.pooler.supabase.com` is an ELB behind three rotating IPs.

In `deploy-production.yml` that failure mode lands **after** `docker compose down`, so a transient DNS or TCP blip would abort the migration and fire the rollback path over a network hiccup rather than a real fault.

Adds `-connectRetries=10 -connectRetriesInterval=5` to `scripts/flyway.sh`, giving Flyway up to 50 seconds to establish a connection before it gives up. Applies to every invocation, so `info`, `baseline` and `migrate` all benefit.

Part of #219.