### PR TITLE
fix: Restore result recording in production

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotRegion.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/tournament/RiotRegion.kt
@@ -18,7 +18,10 @@ enum class RiotRegion(
     ;
 
     companion object {
+        /** Riot returns the region enum on some payloads and the platformId on others. */
         fun platformIdOf(region: String): String? =
-            entries.firstOrNull { it.name.equals(region, ignoreCase = true) }?.platformId
+            entries.firstOrNull {
+                it.name.equals(region, ignoreCase = true) || it.platformId.equals(region, ignoreCase = true)
+            }?.platformId
     }
 }

--- a/src/migrations/sql/V013__fix_games_ownership_and_default_privileges.sql
+++ b/src/migrations/sql/V013__fix_games_ownership_and_default_privileges.sql
@@ -1,0 +1,27 @@
+START TRANSACTION;
+SET search_path = dennys;
+
+-- V012 created `games` fresh instead of renaming it, so it is owned by whoever ran the DDL rather
+-- than the role the application connects as. Align it with the table V012 renamed, which by
+-- construction still carries the schema's original ownership, so this holds in every environment
+-- without naming a role.
+DO $$
+DECLARE
+  app_role name;
+BEGIN
+  SELECT pg_get_userbyid(relowner) INTO app_role
+    FROM pg_class WHERE oid = 'dennys.tournament_codes'::regclass;
+
+  EXECUTE format('ALTER TABLE dennys.games OWNER TO %I', app_role);
+
+  IF current_user <> app_role THEN
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA dennys GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I',
+      app_role);
+    EXECUTE format(
+      'ALTER DEFAULT PRIVILEGES IN SCHEMA dennys GRANT USAGE, SELECT ON SEQUENCES TO %I',
+      app_role);
+  END IF;
+END $$;
+
+COMMIT;

--- a/src/test/kotlin/gateways/RiotRegionTest.kt
+++ b/src/test/kotlin/gateways/RiotRegionTest.kt
@@ -1,0 +1,35 @@
+package gateways
+
+import com.lowbudgetlcs.gateways.riot.tournament.RiotRegion
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class RiotRegionTest :
+    StringSpec({
+        "the region enum maps to its platformId" {
+            RiotRegion.platformIdOf("NA") shouldBe "NA1"
+            RiotRegion.platformIdOf("EUW") shouldBe "EUW1"
+        }
+
+        // Production games/by-code returns the platformId, not the enum name, and dropping it
+        // leaves riot_match_id null, which disables both duplicate-match guards.
+        "a platformId maps to itself" {
+            RiotRegion.platformIdOf("NA1") shouldBe "NA1"
+            RiotRegion.platformIdOf("EUW1") shouldBe "EUW1"
+        }
+
+        "matching is case insensitive either way" {
+            RiotRegion.platformIdOf("na") shouldBe "NA1"
+            RiotRegion.platformIdOf("na1") shouldBe "NA1"
+        }
+
+        "regions whose platformId equals their name still resolve" {
+            RiotRegion.platformIdOf("KR") shouldBe "KR"
+            RiotRegion.platformIdOf("RU") shouldBe "RU"
+        }
+
+        "an unrecognised region resolves to null" {
+            RiotRegion.platformIdOf("ATLANTIS") shouldBe null
+            RiotRegion.platformIdOf("") shouldBe null
+        }
+    })

--- a/src/test/kotlin/models/RiotMatchIdTest.kt
+++ b/src/test/kotlin/models/RiotMatchIdTest.kt
@@ -16,8 +16,6 @@ class RiotMatchIdTest :
             shouldThrow<IllegalArgumentException> { RiotMatchId("   ") }
         }
 
-        // games/by-code returns the tournament region enum (NA) rather than a
-        // platformId (NA1), so the pull path has to map it before building an id.
         "rejects an id with no separator" {
             shouldThrow<IllegalArgumentException> { RiotMatchId("NA15102531894") }
         }


### PR DESCRIPTION
Production cannot record any result. Every `POST /api/v1/series/{id}/results` returns 500:

```
org.jooq.exception.DataAccessException: SQL [insert into "dennys"."games" ...];
ERROR: permission denied for table games
```

**This is not a failed migration.** Flyway applied V011 and V012 cleanly — the ledger shows both
`success = true`, V011's backfill marked 1308 of 1312 series complete, and all 2185 codes are in
`tournament_codes`. The problem is **object ownership**.

## Root cause

V012 renames `games` → `tournament_codes` and then `CREATE TABLE games`. A rename carries the
table's ownership across; a `CREATE` does not — the new table belongs to whoever ran the DDL.
Flyway connects as `flyway_migrator`, so `dennys.games` ended up the only table in the schema not
owned by the app role:

| Object | Owner |
|---|---|
| `series`, `events`, `teams`, `game_results`, `tournament_codes` | `postgres` |
| **`games`** (+ identity sequence, indexes) | **`flyway_migrator`** |

No table in `dennys` carries an explicit ACL, and the app role is a member of `pg_read_all_data`.
That explains the confusing symptom exactly:

```
has_table_privilege('postgres','dennys.games','SELECT') -> true    (pg_read_all_data)
has_table_privilege('postgres','dennys.games','INSERT') -> false   (not owner, no grant)
```

Reads work, writes are denied. `GET /series/1332` returns 200 while every write 500s.

## Why nothing caught it

Staging rebuilds from `docker-entrypoint-initdb.d` as a single role, and
`scripts/rehearsal/run.sh` runs everything as `PGUSER=postgres`. Both rehearse the *SQL* faithfully
but not the *role separation*, which only exists in production. Closing that is the most valuable
follow-up from this incident — see below.

## Blast radius

`games` holds **0 rows**. No result has ever been recorded since cutover, so there is nothing to
repair and no backfill. The outage is total for result recording but data-clean.

## The fix — V013

The owner is derived from `tournament_codes` rather than hardcoded, so the migration is correct in
every environment without naming a role:

```sql
SELECT pg_get_userbyid(relowner) INTO app_role
  FROM pg_class WHERE oid = 'dennys.tournament_codes'::regclass;
EXECUTE format('ALTER TABLE dennys.games OWNER TO %I', app_role);
```

Default privileges are set only where the migrator and the app role actually differ, so the next
migration that creates a table grants the app role automatically instead of repeating this.

Deriving the role matters: my first attempt hardcoded `postgres` and broke all 13 integration
tests with `role "postgres" does not exist`, because testcontainers defaults its user to `test`.

## Second fix — the region mapping

The same logs carry an unrelated bug:

```
WARN Unknown Riot region 'NA1' on shortcode 'NA050c4-14b0ddd2-...'
```

Production's `games/by-code` returns the **platformId** (`NA1`). `RiotRegion.platformIdOf` matched
only the enum *name* (`NA`), returned null, and `riotMatchIdOf` dropped the match id — the exact
opposite of what #189's 2026-08-01 correction claimed.

Every pulled game would be written with `riot_match_id = null`, disabling both duplicate guards at
once: the cross-code check at `SeriesService.kt:133` is skipped when the id is null, and the
`riot_match_id UNIQUE` index cannot help because NULLs never conflict. TC17 had no protection at
all. Now accepts either form.

## Verification

Both failure modes were reproduced locally against real Postgres before and after the fix:

```
production role shape (migrator separate from app role)
  after V012 -> owner=migrator  appuser INSERT=f     <- reproduces the outage
  after V013 -> owner=appuser   appuser INSERT=t
  new table created by migrator -> appuser INSERT=t  <- recurrence closed

testcontainers shape (single role 'test')
  all 13 migrations OK, owner stays 'test', no default privileges created
```

A direct insert as the app role moves from `permission denied for table games` to a NOT NULL
constraint error — i.e. it now reaches the data layer.

`RiotRegionTest` covers `NA`/`NA1`/`na1`, the `KR`/`RU` cases where platformId equals the name, and
an unknown region. Mutation-verified: reverting to the name-only match fails exactly the two new
cases. `test` and `itest` both green under `--rerun-tasks`, not from cache.

## Note on sequencing

The ownership repair could not be applied out of band. `ALTER TABLE ... OWNER TO` requires
membership in the owning role, and while `flyway_migrator` is a member of `postgres`, the reverse
is not true and cannot be granted — Postgres rejects the circular membership. Flyway itself
connects as the owner, so this migration performs the repair cleanly on deploy with no privilege
manipulation.

## Follow-ups, not in this hotfix

- **Give the rehearsal a separate migrator role** and assert the app role can write every table
  afterwards. This is the check that would have caught the outage before it shipped.
- `/health` never touches the database, so the deploy reported healthy against a schema the app
  could not write.
- #189's correction about `games/by-code` returning the region enum should be annotated as wrong.
