### PR TITLE
feat: Cap tournament codes at 2 per game

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.lowbudgetlcs"
-version = "1.4.0"
+version = "1.4.1"
 
 application {
     mainClass.set("io.ktor.server.netty.EngineMain")

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -42,7 +42,7 @@ import java.time.Instant
 private const val RELAY_METADATA_TAG = "LBLCS"
 
 /** Tournament codes a series may be issued for one game before a result has to be recorded. */
-const val DEFAULT_MAX_CODES_PER_GAME = 3
+const val DEFAULT_MAX_CODES_PER_GAME = 2
 
 @Suppress("LongParameterList")
 class SeriesService(

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -41,6 +41,10 @@ import java.time.Instant
 
 private const val RELAY_METADATA_TAG = "LBLCS"
 
+/** Tournament codes a series may be issued for one game before a result has to be recorded. */
+const val DEFAULT_MAX_CODES_PER_GAME = 3
+
+@Suppress("LongParameterList")
 class SeriesService(
     private val codeRepo: ITournamentCodeRepository,
     private val seriesRepo: ISeriesRepository,
@@ -48,6 +52,7 @@ class SeriesService(
     private val teamRepo: ITeamRepository,
     private val gameRepo: IGameRepository,
     private val gate: IRiotTournamentGateway,
+    private val maxCodesPerGame: Int = DEFAULT_MAX_CODES_PER_GAME,
 ) : ISeriesService {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -309,6 +314,15 @@ class SeriesService(
 
     private fun seriesMetadata(id: SeriesId): String = """{"tag":"$RELAY_METADATA_TAG","seriesId":${id.value}}"""
 
+    /**
+     * Codes issued since the most recent recorded game, coded or codeless. Recording a result ends
+     * the current game, so the allowance resets rather than accumulating across a long series.
+     */
+    private fun codesIssuedForCurrentGame(id: SeriesId): Int {
+        val since = gameRepo.getBySeriesId(id).maxOfOrNull { it.createdAt }
+        return codeRepo.getBySeriesId(id).count { since == null || it.createdAt > since }
+    }
+
     private fun riotMatchIdOf(riotGame: RiotTournamentGamesV5Dto): RiotMatchId? {
         val platformId = RiotRegion.platformIdOf(riotGame.region)
         if (platformId == null) {
@@ -381,6 +395,14 @@ class SeriesService(
             "Provided teams are not part of series with id ${series.id.value}."
         }
         refreshQuietly(series.id)
+        val issued = codesIssuedForCurrentGame(series.id)
+        if (issued >= maxCodesPerGame) {
+            logger.warn("Series '${series.id}' has $issued code(s) for the current game, refusing to issue another.")
+            throw IllegalStateException(
+                "Series '${series.id.value}' has already been issued $issued tournament code(s) for this game. " +
+                    "Report the result of the game that was played, or play a custom game and report the winner.",
+            )
+        }
         logger.debug("Fetching tournament id for event '${series.eventId}'...t add")
         val event =
             eventRepo.getById(series.eventId)

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: MIT
     url: https://github.com/lowbudgetlcs/dennys/blob/main/LICENSE.txt
-  version: 1.4.0
+  version: 1.4.1
 externalDocs:
   description: Find out more about Dennys
   url: https://github.com/lowbudgetlcs/dennys
@@ -832,14 +832,23 @@ paths:
     post:
       summary: Issue a tournament code for a series
       description: |
-        Issues a new Riot tournament code. This is **never** blocked — not by
-        the series being complete, and not by a previous game going
-        unreported. Players must never be prevented from playing, so the worst
-        case here is a wasted code.
+        Issues a new Riot tournament code.
 
-        A replacement for a code that did not work is simply another call to
-        this endpoint. There is no void step: a code with no result does not
-        count towards the game number.
+        A series may be issued at most **3 codes per game**, counted since the
+        most recent recorded game. Recording a result ends the current game and
+        grants a fresh 3 for the next; unused allowance does not roll over. The
+        limit exists to bound calls to Riot, not to control play — a refused
+        request never reaches Riot at all.
+
+        Being at the limit does not prevent anyone from playing. Report the
+        result of the game that was played, or play a custom game and report
+        the winner; either records a game, which resets the allowance. A
+        codeless result from a custom game resets it just as a coded one does.
+
+        Issuance is still not blocked by the series being complete, and a
+        replacement for a code that did not work is simply another call to this
+        endpoint. There is no void step: a code with no result does not count
+        towards the game number, though it does count towards the limit.
       operationId: createGame
       tags:
         - Series (v1)
@@ -881,6 +890,17 @@ paths:
                 $ref: "#/components/schemas/Error"
         "404":
           description: Series or team not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: |
+            The series already holds the maximum of 3 tournament codes for the
+            current game. Riot was not called.
+
+            Record a result to reset the allowance — either report the game
+            that was played, or play a custom game and report the winner.
           content:
             application/json:
               schema:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -834,9 +834,9 @@ paths:
       description: |
         Issues a new Riot tournament code.
 
-        A series may be issued at most **3 codes per game**, counted since the
+        A series may be issued at most **2 codes per game**, counted since the
         most recent recorded game. Recording a result ends the current game and
-        grants a fresh 3 for the next; unused allowance does not roll over. The
+        grants a fresh 2 for the next; unused allowance does not roll over. The
         limit exists to bound calls to Riot, not to control play — a refused
         request never reaches Riot at all.
 
@@ -848,7 +848,9 @@ paths:
         Issuance is still not blocked by the series being complete, and a
         replacement for a code that did not work is simply another call to this
         endpoint. There is no void step: a code with no result does not count
-        towards the game number, though it does count towards the limit.
+        towards the game number, though it does count towards the limit — so a
+        replacement for a bum code spends the second of the two, and the next
+        step after that is a custom game.
       operationId: createGame
       tags:
         - Series (v1)
@@ -896,7 +898,7 @@ paths:
                 $ref: "#/components/schemas/Error"
         "409":
           description: |
-            The series already holds the maximum of 3 tournament codes for the
+            The series already holds the maximum of 2 tournament codes for the
             current game. Riot was not called.
 
             Record a result to reset the allowance — either report the game

--- a/src/test/kotlin/services/PlayerServiceTest.kt
+++ b/src/test/kotlin/services/PlayerServiceTest.kt
@@ -15,7 +15,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.mockk.clearAllMocks
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 
@@ -26,7 +26,7 @@ class PlayerServiceTest : StringSpec({
     val teamRepo = mockk<ITeamRepository>()
     val service = PlayerService(playerRepo, accountRepo, teamRepo)
 
-    beforeEach { clearAllMocks() }
+    beforeEach { clearMocks(playerRepo, accountRepo, teamRepo) }
 
     "getAllPlayers() should return empty list when no players exist" {
         every { playerRepo.getAll() } returns listOf()

--- a/src/test/kotlin/services/SeriesCodeCapTest.kt
+++ b/src/test/kotlin/services/SeriesCodeCapTest.kt
@@ -133,25 +133,25 @@ class SeriesCodeCapTest :
     StringSpec({
         "a code is issued while the series is under the limit" {
             val f = CapFixture()
-            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))))
+            f.holding(codes = listOf(f.code(1, f.at(10))))
 
             f.service.createGame(f.newCode).seriesId shouldBe CAP_SERIES_ID
 
             coVerify(exactly = 1) { f.gateway.getCode(any(), any()) }
         }
 
-        "the fourth code for one game is refused" {
+        "the third code for one game is refused" {
             val f = CapFixture()
-            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))))
 
             val ex = shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
 
-            ex.message.toString() shouldContain "already been issued 3 tournament code(s) for this game"
+            ex.message.toString() shouldContain "already been issued 2 tournament code(s) for this game"
         }
 
         "a refused request never reaches Riot" {
             val f = CapFixture()
-            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))))
 
             shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
 
@@ -160,7 +160,7 @@ class SeriesCodeCapTest :
 
         "the refusal names both remedies" {
             val f = CapFixture()
-            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))))
 
             val ex = shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
 
@@ -171,8 +171,8 @@ class SeriesCodeCapTest :
         "recording a game grants a fresh allowance" {
             val f = CapFixture()
             f.holding(
-                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))),
-                games = listOf(f.game(1, f.at(40), TournamentCodeId(3))),
+                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))),
+                games = listOf(f.game(1, f.at(40), TournamentCodeId(2))),
             )
 
             f.service.createGame(f.newCode)
@@ -183,7 +183,7 @@ class SeriesCodeCapTest :
         "a codeless game from a custom resets the allowance just as a coded one does" {
             val f = CapFixture()
             f.holding(
-                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))),
+                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))),
                 games = listOf(f.game(1, f.at(40), tournamentCodeId = null)),
             )
 
@@ -199,11 +199,9 @@ class SeriesCodeCapTest :
                     listOf(
                         f.code(1, f.at(10)),
                         f.code(2, f.at(20)),
-                        f.code(3, f.at(30)),
-                        f.code(4, f.at(50)),
-                        f.code(5, f.at(60)),
+                        f.code(3, f.at(50)),
                     ),
-                games = listOf(f.game(1, f.at(40), TournamentCodeId(3))),
+                games = listOf(f.game(1, f.at(40), TournamentCodeId(2))),
             )
 
             f.service.createGame(f.newCode)
@@ -219,7 +217,6 @@ class SeriesCodeCapTest :
                         f.code(1, f.at(10)),
                         f.code(4, f.at(50)),
                         f.code(5, f.at(60)),
-                        f.code(6, f.at(70)),
                     ),
                 games = listOf(f.game(1, f.at(40), TournamentCodeId(1))),
             )

--- a/src/test/kotlin/services/SeriesCodeCapTest.kt
+++ b/src/test/kotlin/services/SeriesCodeCapTest.kt
@@ -1,0 +1,240 @@
+package services
+
+import com.lowbudgetlcs.domain.event.models.Event
+import com.lowbudgetlcs.domain.event.models.Shortcode
+import com.lowbudgetlcs.domain.event.models.toEventDescription
+import com.lowbudgetlcs.domain.event.models.toEventName
+import com.lowbudgetlcs.domain.event.models.toRiotTournamentId
+import com.lowbudgetlcs.domain.event.models.types.EventId
+import com.lowbudgetlcs.domain.event.models.types.EventStage
+import com.lowbudgetlcs.domain.event.models.types.EventStatus
+import com.lowbudgetlcs.domain.series.DEFAULT_MAX_CODES_PER_GAME
+import com.lowbudgetlcs.domain.series.SeriesService
+import com.lowbudgetlcs.domain.series.game.models.Game
+import com.lowbudgetlcs.domain.series.game.models.GameResult
+import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
+import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.types.GameId
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
+import com.lowbudgetlcs.domain.series.models.Series
+import com.lowbudgetlcs.domain.series.models.types.SeriesId
+import com.lowbudgetlcs.domain.team.models.Team
+import com.lowbudgetlcs.domain.team.models.toTeamName
+import com.lowbudgetlcs.domain.team.models.types.TeamId
+import com.lowbudgetlcs.gateways.riot.tournament.IRiotTournamentGateway
+import com.lowbudgetlcs.gateways.riot.tournament.RiotShortcodeDto
+import com.lowbudgetlcs.repositories.event.IEventRepository
+import com.lowbudgetlcs.repositories.game.IGameRepository
+import com.lowbudgetlcs.repositories.series.ISeriesRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+
+private val CAP_BLUE = TeamId(1)
+private val CAP_RED = TeamId(2)
+private val CAP_SERIES_ID = SeriesId(70)
+private val CAP_EVENT_ID = EventId(1)
+private val CAP_AT = Instant.parse("2026-08-11T12:00:00Z")
+
+private class CapFixture(
+    maxCodesPerGame: Int = DEFAULT_MAX_CODES_PER_GAME,
+) {
+    val codeRepo = mockk<ITournamentCodeRepository>(relaxed = false)
+    val seriesRepo = mockk<ISeriesRepository>(relaxed = false)
+    val eventRepo = mockk<IEventRepository>(relaxed = false)
+    val teamRepo = mockk<ITeamRepository>(relaxed = false)
+    val gameRepo = mockk<IGameRepository>(relaxed = false)
+    val gateway = mockk<IRiotTournamentGateway>(relaxed = false)
+    val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gateway, maxCodesPerGame)
+
+    val newCode = NewTournamentCode(CAP_SERIES_ID, CAP_BLUE, CAP_RED)
+
+    private val series =
+        Series(
+            id = CAP_SERIES_ID,
+            eventId = CAP_EVENT_ID,
+            eventStage = EventStage.PLAYOFFS,
+            totalGames = 5,
+            participants = Pair(CAP_BLUE, CAP_RED),
+            result = null,
+            completed = false,
+            completedAt = null,
+            reopenedAt = null,
+        )
+
+    private val event =
+        Event(
+            id = CAP_EVENT_ID,
+            name = "Test".toEventName(),
+            description = "Testing".toEventDescription(),
+            riotTournamentId = 1.toRiotTournamentId(),
+            createdAt = CAP_AT,
+            startDate = CAP_AT,
+            endDate = CAP_AT.plusSeconds(3_600L),
+            status = EventStatus.ACTIVE,
+            eventGroupId = null,
+            eventStages = setOf(EventStage.PLAYOFFS),
+        )
+
+    fun code(
+        id: Int,
+        createdAt: Instant,
+    ) = TournamentCode(
+        id = TournamentCodeId(id),
+        shortcode = Shortcode("SHORT-$id"),
+        blueTeamId = CAP_BLUE,
+        redTeamId = CAP_RED,
+        seriesId = CAP_SERIES_ID,
+        createdAt = createdAt,
+    )
+
+    fun game(
+        id: Int,
+        createdAt: Instant,
+        tournamentCodeId: TournamentCodeId? = null,
+    ) = Game(
+        id = GameId(id),
+        seriesId = CAP_SERIES_ID,
+        tournamentCodeId = tournamentCodeId,
+        riotMatchId = null,
+        number = id,
+        createdAt = createdAt,
+        result = GameResult(CAP_BLUE, CAP_RED),
+    )
+
+    /** Wires a series that is ready to issue, holding [codes] and [games]. */
+    fun holding(
+        codes: List<TournamentCode> = emptyList(),
+        games: List<Game> = emptyList(),
+    ) {
+        every { seriesRepo.getById(CAP_SERIES_ID) } returns series
+        every { codeRepo.getBySeriesId(CAP_SERIES_ID) } returns codes
+        every { gameRepo.getBySeriesId(CAP_SERIES_ID) } returns games
+        every { teamRepo.getById(CAP_BLUE) } returns Team(CAP_BLUE, "Blue".toTeamName(), null, CAP_EVENT_ID)
+        every { teamRepo.getById(CAP_RED) } returns Team(CAP_RED, "Red".toTeamName(), null, CAP_EVENT_ID)
+        every { eventRepo.getById(CAP_EVENT_ID) } returns event
+        coEvery { gateway.getGames(any()) } returns emptyList()
+        coEvery { gateway.getCode(any(), any()) } returns RiotShortcodeDto(listOf("SHORT-NEW"))
+        every { codeRepo.insert(any(), any()) } returns code(99, CAP_AT.plusSeconds(999))
+    }
+
+    fun at(seconds: Long): Instant = CAP_AT.plusSeconds(seconds)
+}
+
+class SeriesCodeCapTest :
+    StringSpec({
+        "a code is issued while the series is under the limit" {
+            val f = CapFixture()
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20))))
+
+            f.service.createGame(f.newCode).seriesId shouldBe CAP_SERIES_ID
+
+            coVerify(exactly = 1) { f.gateway.getCode(any(), any()) }
+        }
+
+        "the fourth code for one game is refused" {
+            val f = CapFixture()
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+
+            val ex = shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
+
+            ex.message.toString() shouldContain "already been issued 3 tournament code(s) for this game"
+        }
+
+        "a refused request never reaches Riot" {
+            val f = CapFixture()
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+
+            shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
+
+            coVerify(exactly = 0) { f.gateway.getCode(any(), any()) }
+        }
+
+        "the refusal names both remedies" {
+            val f = CapFixture()
+            f.holding(codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))))
+
+            val ex = shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
+
+            ex.message.toString() shouldContain "Report the result"
+            ex.message.toString() shouldContain "custom game"
+        }
+
+        "recording a game grants a fresh allowance" {
+            val f = CapFixture()
+            f.holding(
+                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))),
+                games = listOf(f.game(1, f.at(40), TournamentCodeId(3))),
+            )
+
+            f.service.createGame(f.newCode)
+
+            coVerify(exactly = 1) { f.gateway.getCode(any(), any()) }
+        }
+
+        "a codeless game from a custom resets the allowance just as a coded one does" {
+            val f = CapFixture()
+            f.holding(
+                codes = listOf(f.code(1, f.at(10)), f.code(2, f.at(20)), f.code(3, f.at(30))),
+                games = listOf(f.game(1, f.at(40), tournamentCodeId = null)),
+            )
+
+            f.service.createGame(f.newCode)
+
+            coVerify(exactly = 1) { f.gateway.getCode(any(), any()) }
+        }
+
+        "bum codes from an earlier game do not count against the current one" {
+            val f = CapFixture()
+            f.holding(
+                codes =
+                    listOf(
+                        f.code(1, f.at(10)),
+                        f.code(2, f.at(20)),
+                        f.code(3, f.at(30)),
+                        f.code(4, f.at(50)),
+                        f.code(5, f.at(60)),
+                    ),
+                games = listOf(f.game(1, f.at(40), TournamentCodeId(3))),
+            )
+
+            f.service.createGame(f.newCode)
+
+            coVerify(exactly = 1) { f.gateway.getCode(any(), any()) }
+        }
+
+        "the allowance counts only codes issued since the most recent game" {
+            val f = CapFixture()
+            f.holding(
+                codes =
+                    listOf(
+                        f.code(1, f.at(10)),
+                        f.code(4, f.at(50)),
+                        f.code(5, f.at(60)),
+                        f.code(6, f.at(70)),
+                    ),
+                games = listOf(f.game(1, f.at(40), TournamentCodeId(1))),
+            )
+
+            shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
+
+            coVerify(exactly = 0) { f.gateway.getCode(any(), any()) }
+        }
+
+        "the limit is configurable" {
+            val f = CapFixture(maxCodesPerGame = 1)
+            f.holding(codes = listOf(f.code(1, f.at(10))))
+
+            shouldThrow<IllegalStateException> { f.service.createGame(f.newCode) }
+
+            coVerify(exactly = 0) { f.gateway.getCode(any(), any()) }
+        }
+    })

--- a/src/test/kotlin/services/SeriesServiceTest.kt
+++ b/src/test/kotlin/services/SeriesServiceTest.kt
@@ -33,7 +33,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import io.mockk.clearAllMocks
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -49,7 +49,7 @@ class SeriesServiceTest :
         val gameRepo = mockk<IGameRepository>(relaxed = false)
         val service = SeriesService(codeRepo, seriesRepo, eventRepo, teamRepo, gameRepo, gameGateway)
 
-        beforeTest { clearAllMocks() }
+        beforeTest { clearMocks(codeRepo, eventRepo, teamRepo, seriesRepo, gameGateway, gameRepo) }
 
         val event =
             Event(
@@ -292,7 +292,7 @@ class SeriesServiceTest :
                 listOf(team1.id, team2.id, team1.id, team1.id),
                 listOf(team1.id, team2.id, team1.id, team2.id, team1.id),
             ).forEach { winners ->
-                clearAllMocks()
+                clearMocks(codeRepo, eventRepo, teamRepo, seriesRepo, gameGateway, gameRepo)
                 val series = seriesOf(5)
                 arrange(series, winners)
 
@@ -303,7 +303,7 @@ class SeriesServiceTest :
                 }
             }
 
-            clearAllMocks()
+            clearMocks(codeRepo, eventRepo, teamRepo, seriesRepo, gameGateway, gameRepo)
             val drawn = seriesOf(5)
             arrange(drawn, listOf(team1.id, team2.id, team1.id, team2.id))
 

--- a/src/test/kotlin/services/TeamServiceTest.kt
+++ b/src/test/kotlin/services/TeamServiceTest.kt
@@ -15,7 +15,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import io.mockk.clearAllMocks
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,7 +27,7 @@ class TeamServiceTest :
         val playerRepo = mockk<IPlayerRepository>(relaxed = false)
         val service = TeamService(teamRepo, playerRepo)
 
-        beforeTest { clearAllMocks() }
+        beforeTest { clearMocks(teamRepo, playerRepo) }
 
         "createTeam succeeds for valid input" {
             val newTeam = NewTeam(TeamName("Golden Guardians"), null)


### PR DESCRIPTION
Closes #230. Targets `release/1.4.1`.

Nothing bounded tournament-code issuance — verified at every layer: no check in
`SeriesService.createGame`, no count method on `ITournamentCodeRepository`, no database
constraint, no DTO validation. `totalGames` bounds nothing either; its only behavioural use is the
auto-close threshold. The result was unbounded calls to Riot's `POST /codes`: production
accumulated series far past any sane per-game figure, one of them holding **7 codes**, with Bo5
series the worst affected.

## The rule

At most **2 codes per game**, counted since the most recent recorded game. Recording a result ends
the current game and grants a fresh 2; unused allowance does not roll over.

Counting a per-game window rather than outstanding codes is deliberate. Over a multi-hour series
with Riot flapping, unconsumed bum codes would otherwise pile up and keep the series locked out
even after Riot recovered — a tighter cap makes that failure mode worse, so the window matters
more at 2 than it would at 3. Two properties follow:

- **Any** recorded game resets the budget, including a **codeless** one — so playing a custom and
  self-reporting is both the escape hatch and the reset.
- Codes from earlier games never count against the current game.

Normal play — one code per game — uses one of the two, leaving exactly one replacement for a bum
code before a custom game becomes the next step.

## Placement carries the design

The check sits between `refreshQuietly` and `gate.getCode`:

- **After `refreshQuietly`**, because that runs `refreshFromRiot`, which inserts `Game` rows for
  Riot-confirmed results. A game just played resets the budget *before* we count, so the limit is
  self-healing rather than sticky.
- **Before `gate.getCode`**, the only point a real Riot code is consumed. A refused request never
  reaches Riot, which is the entire objective. `coVerify(exactly = 0)` asserts exactly this.

`check`-style `IllegalStateException` → **409**, matching `removeSeries` and `completeSeries`. The
message names both remedies.

The limit is `DEFAULT_MAX_CODES_PER_GAME = 2`, exposed as a defaulted constructor parameter — one
obvious place to change it, all nine existing fixtures compile untouched, and tests drive it with
a smaller value instead of issuing two codes through the mocked gateway.

## This reverses a documented decision

#189 states "**No gate on code generation**", and the spec promised the endpoint was "**never**
blocked... Players must never be prevented from playing". Both are amended here with the anti-spam
rationale recorded, so the old behaviour is not restored by someone reading the old text. Players
still are not blocked from *playing* — only from a third code.

## Second commit: a latent test bug this exposed

The nine new tests passed alone and failed together. `ProjectConfig` runs specs **and** tests
concurrently, and three specs called `clearAllMocks()` between their own tests — which is global
and wipes the stubs of whatever other spec is mid-run. Any spec with a wide enough window loses
the race and dies with a `MockKException`.

Replaced with `clearMocks(...)` over each spec's own mocks, which is what the between-test reset
was for. This was pre-existing, latent, and would have surfaced as random CI failures as the suite
grew.

## Third commit: retuned from 3 to 2

The business rule is two codes per game. Beyond the constant, two things needed more than a digit
swap:

- The spec's bum-code paragraph now states what the tighter limit means in practice — a
  replacement for a dead code spends the second of the two, so the next step after that is a
  custom game.
- Three cap tests held two or three codes as "comfortably under" or "just over" a limit of three,
  so they landed on the wrong side of a limit of two. Each was re-pitched at the boundary it was
  written for rather than having its numbers swapped: the under-the-limit case holds one code, the
  refusal cases hold exactly two, and the two earlier-game cases keep a spent allowance behind the
  recorded game while leaving the current game under the limit.

## Verification

- Mutation-verified: removing the guard fails all five refusal tests and no others — re-confirmed
  after the retune.
- `test` green under `--rerun-tasks`; all nine cap tests pass, and the refusal message reads
  "issued 2 tournament code(s)".
- No new detekt findings — `SeriesService.kt` stays at its baseline of 8; the constructor carries
  a targeted `@Suppress("LongParameterList")`.
- Spec validated: `createGame` now documents 409, and `info.version` is `1.4.1`.
- **Note:** `ktlintCheck` fails on this branch, but every violation is pre-existing and in files
  this PR does not touch (`Argon2Hasher.kt`, `EventTypesTest.kt`, `UsernameTests.kt`,
  `PatchEventTest.kt`, `EventGroupServiceTest.kt`, plus wrapping nits in `PlayerServiceTest.kt` /
  `TeamServiceTest.kt`). The three files changed here are ktlint-clean. Worth a separate cleanup —
  an earlier revision of this description claimed ktlint was clean, and it is not.

## Note for clients

`POST /game` can now return 409. todd-bot#97 should surface the message rather than treating it as
a generic failure, and todd-bot#126 / todd-bot#127 cover that work.

todd-bot's `TOURNAMENT_CODE_LIMIT` was **already 2** while this branch enforced 3. Todd would have
greyed out Generate Next Game while dennys was still willing to issue a third code, locking
captains out of a code they were owed. Landing at 2 on both sides is what stops that mismatch
shipping.

Day-one impact: the only series known to be over the limit is 1332, the stress-test series; the
current count at 2 has not been measured.

## Known race, accepted

`TournamentCodeRepository.insert` takes no advisory lock, unlike `GameRepository.insert`, so two
simultaneous requests can overshoot by one code (TC8). A one-code overshoot does not undermine an
anti-spam bound, and the alternative pushes a business rule into the repository.
