### PR TITLE
fix: Send the PUUID, not the Puuid wrapper, to Riot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.lowbudgetlcs"
-version = "1.4.0"
+version = "1.4.1"
 
 application {
     mainClass.set("io.ktor.server.netty.EngineMain")

--- a/src/main/kotlin/com/lowbudgetlcs/domain/account/models/types/Puuid.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/account/models/types/Puuid.kt
@@ -2,11 +2,22 @@ package com.lowbudgetlcs.domain.account.models.types
 
 const val PUUID_LENGTH = 78
 
+/**
+ * Riot PUUIDs are base64url, so the charset is checked as well as the length. This is a security
+ * boundary, not just tidiness: the value reaches a Riot URL as a path segment, and a caller-supplied
+ * value carrying '/' or '..' could otherwise redirect that request to another path on Riot's host
+ * with our API key attached.
+ */
+private val PUUID_CHARSET = Regex("[A-Za-z0-9_-]*")
+
 @JvmInline
 value class Puuid(
     val value: String,
 ) {
     init {
-        require(value.length == PUUID_LENGTH) { "Puuids must be exactly 78 characters." }
+        require(value.length == PUUID_LENGTH) { "Puuids must be exactly $PUUID_LENGTH characters." }
+        require(PUUID_CHARSET.matches(value)) {
+            "Puuids must contain only letters, digits, '-' and '_'."
+        }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/gateways/riot/account/RiotAccountGateway.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/gateways/riot/account/RiotAccountGateway.kt
@@ -8,7 +8,9 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.request
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.appendPathSegments
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -20,9 +22,23 @@ class RiotAccountGateway(
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     override suspend fun getAccountByPuuid(puuid: Puuid): RiotAccount {
-        logger.debug("Fetching account for '$puuid'...")
+        logger.debug("Fetching account for '${puuid.value}'...")
         val response: HttpResponse =
-            client.get("$baseUrl/riot/account/v1/accounts/by-puuid/$puuid") {
+            client.get(baseUrl) {
+                // Appended as a path segment rather than interpolated: interpolating the Puuid
+                // wrapper sent its toString(), so Riot received 'Puuid(value=...)' and answered
+                // 400, which surfaced to clients as "Invalid Riot PUUID" for valid accounts.
+                url {
+                    appendPathSegments(
+                        "riot",
+                        "account",
+                        "v1",
+                        "accounts",
+                        "by-puuid",
+                        puuid.value,
+                        encodeSlash = true,
+                    )
+                }
                 headers {
                     append("X-Riot-Token", apiKey)
                 }
@@ -34,10 +50,16 @@ class RiotAccountGateway(
                 response.body<RiotAccountDto>().toRiotAccount()
             }
 
-            HttpStatusCode.BadRequest -> throw IllegalArgumentException("Invalid Riot PUUID")
+            HttpStatusCode.BadRequest -> {
+                // Puuid validates its own format, so Riot rejecting the value points at the
+                // request we built rather than at the caller. Name the URL to keep that visible.
+                logger.warn("Riot rejected the PUUID in '${response.request.url}' as malformed.")
+                throw IllegalArgumentException("Invalid Riot PUUID")
+            }
+
             HttpStatusCode.NotFound -> throw NoSuchElementException("Riot account not found for PUUID")
             else -> {
-                logger.warn("Failed to fetch account.")
+                logger.warn("Failed to fetch account from '${response.request.url}': ${response.status}")
                 throw RiotApiException("Unexpected Riot API error: ${response.status}", response.status.value)
             }
         }

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: MIT
     url: https://github.com/lowbudgetlcs/dennys/blob/main/LICENSE.txt
-  version: 1.4.0
+  version: 1.4.1
 externalDocs:
   description: Find out more about Dennys
   url: https://github.com/lowbudgetlcs/dennys
@@ -1544,7 +1544,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/RiotAccountDto"
         "400":
-          description: Invalid PUUID format
+          description: Malformed request body
+        "422":
+          description: |
+            Invalid PUUID. A PUUID must be exactly 78 base64url characters
+            (letters, digits, '-' and '_'); anything else is rejected before
+            Riot is called. Riot rejecting the value also surfaces here.
         "404":
           description: Riot account not found from Riot API
         "409":

--- a/src/test/kotlin/gateways/RiotAccountGatewayTest.kt
+++ b/src/test/kotlin/gateways/RiotAccountGatewayTest.kt
@@ -1,0 +1,131 @@
+package gateways
+
+import com.lowbudgetlcs.domain.account.models.types.Puuid
+import com.lowbudgetlcs.gateways.riot.RiotApiException
+import com.lowbudgetlcs.gateways.riot.account.RiotAccountGateway
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/** The account from the production report that returned 422 for a PUUID Riot itself accepts. */
+private const val FULL_METAL_PUUID = "wtATP4ScufpCsr8o7FaDd2wQu5u3dZjPWLiU-W0dJ41EVO_JuSrDDBV680ygdBARc7H7GARUTtJjeA"
+
+private val ACCOUNT_PAYLOAD =
+    """
+    {
+      "puuid": "$FULL_METAL_PUUID",
+      "gameName": "Full Metal",
+      "tagLine": "FLAME"
+    }
+    """.trimIndent()
+
+private fun gatewayOf(engine: MockEngine) =
+    RiotAccountGateway(
+        client =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            },
+        apiKey = "test-key",
+    )
+
+/** Records the single request the gateway makes so its URL can be asserted on. */
+private class Recorder {
+    var request: HttpRequestData? = null
+
+    fun ok() =
+        MockEngine { req ->
+            request = req
+            respond(
+                ACCOUNT_PAYLOAD,
+                HttpStatusCode.OK,
+                headersOf("Content-Type", ContentType.Application.Json.toString()),
+            )
+        }
+
+    val url: String get() = request?.url?.toString() ?: error("no request was made")
+}
+
+class RiotAccountGatewayTest :
+    StringSpec({
+        val puuid = Puuid(FULL_METAL_PUUID)
+
+        "the request path carries the bare PUUID, not the wrapper type's toString" {
+            val recorder = Recorder()
+
+            gatewayOf(recorder.ok()).getAccountByPuuid(puuid)
+
+            recorder.url shouldContain "/riot/account/v1/accounts/by-puuid/$FULL_METAL_PUUID"
+            recorder.url shouldNotContain "Puuid("
+            recorder.url shouldNotContain "value="
+        }
+
+        "the PUUID is the final path segment, with nothing appended" {
+            val recorder = Recorder()
+
+            gatewayOf(recorder.ok()).getAccountByPuuid(puuid)
+
+            recorder.url.substringAfterLast('/') shouldBe FULL_METAL_PUUID
+        }
+
+        "the API key is sent as X-Riot-Token" {
+            val recorder = Recorder()
+
+            gatewayOf(recorder.ok()).getAccountByPuuid(puuid)
+
+            recorder.request?.headers?.get("X-Riot-Token") shouldBe "test-key"
+        }
+
+        "a 200 maps the payload onto the domain account" {
+            val gateway = gatewayOf(Recorder().ok())
+
+            gateway.getAccountByPuuid(puuid).riotPuuid shouldBe puuid
+        }
+
+        "a 400 is an invalid-PUUID argument failure" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.BadRequest) })
+
+            val ex = shouldThrow<IllegalArgumentException> { gateway.getAccountByPuuid(puuid) }
+
+            ex.message.toString() shouldContain "Invalid Riot PUUID"
+        }
+
+        "a 404 is a missing account, distinct from a malformed one" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.NotFound) })
+
+            shouldThrow<NoSuchElementException> { gateway.getAccountByPuuid(puuid) }
+        }
+
+        "a 403 is a Riot API failure, not the caller's fault" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.Forbidden) })
+
+            val ex = shouldThrow<RiotApiException> { gateway.getAccountByPuuid(puuid) }
+
+            ex.status shouldBe 403
+            ex.retryable shouldBe false
+        }
+
+        "a 429 is reported as retryable" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.TooManyRequests) })
+
+            shouldThrow<RiotApiException> { gateway.getAccountByPuuid(puuid) }.retryable shouldBe true
+        }
+
+        "a 500 is reported as retryable" {
+            val gateway = gatewayOf(MockEngine { respondError(HttpStatusCode.InternalServerError) })
+
+            shouldThrow<RiotApiException> { gateway.getAccountByPuuid(puuid) }.retryable shouldBe true
+        }
+    })

--- a/src/test/kotlin/models/PuuidTest.kt
+++ b/src/test/kotlin/models/PuuidTest.kt
@@ -1,0 +1,66 @@
+package models
+
+import com.lowbudgetlcs.domain.account.models.toPuuid
+import com.lowbudgetlcs.domain.account.models.types.PUUID_LENGTH
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/** A real PUUID, from the account whose registration this validation had to keep working. */
+private const val VALID_PUUID = "wtATP4ScufpCsr8o7FaDd2wQu5u3dZjPWLiU-W0dJ41EVO_JuSrDDBV680ygdBARc7H7GARUTtJjeA"
+
+/** Builds a [PUUID_LENGTH]-character string ending in [suffix], so only the charset is under test. */
+private fun paddedWith(suffix: String) = "a".repeat(PUUID_LENGTH - suffix.length) + suffix
+
+class PuuidTest :
+    StringSpec({
+        "a real PUUID is accepted, and keeps its value" {
+            shouldNotThrow<IllegalArgumentException> { VALID_PUUID.toPuuid() }
+            VALID_PUUID.toPuuid().value shouldBe VALID_PUUID
+        }
+
+        "letters, digits, '-' and '_' are all valid" {
+            shouldNotThrow<IllegalArgumentException> { paddedWith("aZ09-_").toPuuid() }
+        }
+
+        "a PUUID one character short is rejected" {
+            shouldThrow<IllegalArgumentException> { "a".repeat(PUUID_LENGTH - 1).toPuuid() }
+        }
+
+        "a PUUID one character long is rejected" {
+            shouldThrow<IllegalArgumentException> { "a".repeat(PUUID_LENGTH + 1).toPuuid() }
+        }
+
+        "an empty PUUID is rejected" {
+            shouldThrow<IllegalArgumentException> { "".toPuuid() }
+        }
+
+        // The value is appended to a Riot URL as a path segment. Correct length is not enough:
+        // these would each steer the request somewhere other than the account resource.
+        "a path traversal of the right length is rejected" {
+            shouldThrow<IllegalArgumentException> { paddedWith("/../../lol").toPuuid() }
+        }
+
+        "a query string of the right length is rejected" {
+            shouldThrow<IllegalArgumentException> { paddedWith("?api_key=x").toPuuid() }
+        }
+
+        "a fragment of the right length is rejected" {
+            shouldThrow<IllegalArgumentException> { paddedWith("#frag").toPuuid() }
+        }
+
+        "a percent-encoded slash of the right length is rejected" {
+            shouldThrow<IllegalArgumentException> { paddedWith("%2F..").toPuuid() }
+        }
+
+        "whitespace of the right length is rejected" {
+            shouldThrow<IllegalArgumentException> { paddedWith("  ").toPuuid() }
+        }
+
+        "the wrapper's own toString is not a valid PUUID" {
+            // Guards the shape of the original bug: had this ever round-tripped, the malformed
+            // URL would have been accepted as a legitimate value.
+            shouldThrow<IllegalArgumentException> { VALID_PUUID.toPuuid().toString().toPuuid() }
+        }
+    })


### PR DESCRIPTION
Closes #232. Targets `release/1.4.1`.

`POST /api/v1/account` rejected every valid PUUID with `422 Invalid Riot PUUID` — account
registration was completely broken in production.

The URL was built with `$puuid` instead of the wrapped string. `Puuid` is a `@JvmInline value
class`, so Kotlin's generated `toString()` put the wrapper form into the path:

```
GET /riot/account/v1/accounts/by-puuid/Puuid(value=wtATP4Sc…JjeA)
```

Riot answers 400 → `IllegalArgumentException("Invalid Riot PUUID")` → 422. The identical defect in
the log statement one line above is why production logs showed `Puuid(value=…)` and made the
outbound request look correct.

## The fix

`appendPathSegments(..., encodeSlash = true)` instead of interpolation. `.value` alone would fix
today's symptom, but the builder also encodes the segment, which matters for the hardening below —
Ktor leaves `/` unencoded inside a segment by default, so `encodeSlash = true` is doing real work
rather than being decoration.

`Puuid` now validates its charset as well as its length. That is a security boundary, not tidiness:
the value comes straight from a client through `NewAccountDto.riotPuuid`, and a crafted
78-character string containing `/` or `..` could otherwise redirect the request to a different path
on `americas.api.riotgames.com` **with our Riot API key attached**. Low severity — authenticated
callers only, GET only, response never reflected — but worth closing at the type where every
construction path benefits, including `AccountRepository`'s reads.

Confirmed safe before tightening: all **701** PUUIDs in production match `^[A-Za-z0-9_-]{78}$`, so
no existing row is rejected. The `players.riot_puuid` column is `CHAR(78)`, so it cannot carry
padding at that width either.

Failure logging now names the URL that failed, on both the 400 and the catch-all branches, the way
`getGames` already does. A 400 reported as "invalid client input" is precisely what made this bug
expensive to find.

## Why this reached production

`RiotTournamentGateway` gets this right in both of its interpolations. The difference is that it
has `RiotTournamentGatewayTest` driving a `MockEngine`, and **`RiotAccountGateway` had no test at
all** — nothing had ever asserted on the URL it builds.

`RiotAccountGatewayTest` is new and closes that gap: the request URL, the `X-Riot-Token` header,
the 200 mapping, and the full status matrix (400 → argument, 404 → not-found, 403 → terminal,
429/500 → retryable). `PuuidTest` covers the length bounds plus traversal, query, fragment,
percent-encoded and whitespace payloads at exactly 78 characters.

**Verified red first:** against unmodified `src/`, the two URL assertions fail with

```
expected: wtATP4Sc…JjeA
but was:  Puuid(value=wtATP4Sc…JjeA)
```

which is byte-for-byte the URL production sent. The test binds to the real defect, not to a
plausible restatement of it.

## Second commit: version bump and a spec correction

`release/1.4.1` still declared `version = "1.4.0"`. The staging workflow derives both the image tag
and the environment hostname from that property, so pushing without the bump would have retagged
`lblcs/dennys:1.4.0` and redeployed the existing **dennys-140** environment instead of standing up
**dennys-141**. No production risk either way — production runs `:latest`, not `:<version>` — but
the 1.4.0 staging image and environment would have been overwritten.

PR #231 makes the identical `1.4.0` → `1.4.1` edit, so it 3-way merges onto this cleanly.

The spec also promised `400: Invalid PUUID format`, which the app never returns for that case — it
returns 422 via the `IllegalArgumentException` handler, and 400 is reserved for a malformed body.
Corrected here rather than left for the generated clients to trip over.

## Verification

- New tests fail against pre-fix `src/`, pass after. `./gradlew test --rerun-tasks` green
  (`RiotAccountGatewayTest` 9, `PuuidTest` 11).
- `detekt` clean. All four touched files are ktlint-clean; `ktlintCheck` does fail on this branch,
  but every violation pre-exists in files this PR does not touch — verified by running it on
  `release/1.4.1` before any edit. Worth a separate cleanup pass.
- OpenAPI parses, `info.version` is `1.4.1`.

**Still to do after merge** — the checks a mock cannot make:

1. Confirm the staging workflow ran and `https://dennys-141.lowbudgetlcs.com/health` returns 200
   with `/swagger` reporting 1.4.1. Note no workflow has ever run on `release/1.4.1`: the branch
   was created as a pointer, and this workflow's `paths-ignore` filter means GitHub does not
   evaluate it for a branch-creation push.
2. `POST /api/v1/account` against staging with the Full Metal#FLAME PUUID must return **201**, with
   the staging log showing a URL ending in the bare PUUID. This is the only step that proves the
   fix against live Riot.
3. A 78-character PUUID containing `../` must return 422 without reaching Riot.

## Note on #155

#155 replaces this endpoint's input with `gameName#tagLine`, which means calling
`accounts/by-riot-id/{gameName}/{tagLine}` — two segments of real user text, with spaces and
non-ASCII. It must use the same path-segment building; interpolating there would reintroduce this
exact class of bug with a much wider input space.
