### PR TITLE
fix: Stop refusing to link an account that has no owner

### DIFF
--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/PlayerService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/PlayerService.kt
@@ -75,7 +75,11 @@ class PlayerService(
         logger.info("Linking account '$accountId' to player '$playerId'...")
         this.getPlayer(playerId) // throws if not found
         val account = accountRepository.getById(accountId) ?: throw NoSuchElementException("Account does not exist")
-        checkNotNull(account.playerId) { "Account already owned." }
+        // Free to claim, or already this player's — re-linking an account to its current owner is a
+        // no-op rather than a conflict, so a retried link does not fail. Only another player's
+        // account is refused, which is what the spec documents for this 409.
+        val owner = account.playerId
+        check(owner == null || owner == playerId) { "Account already owned by player ${owner?.value}." }
         accountRepository.updatePlayerId(accountId, playerId)
             ?: throw DatabaseException("Failed to link account to player.")
         val player = playerRepository.getById(playerId) ?: throw NoSuchElementException("Player not found.")

--- a/src/test/kotlin/services/PlayerAccountLinkTest.kt
+++ b/src/test/kotlin/services/PlayerAccountLinkTest.kt
@@ -1,0 +1,104 @@
+package services
+
+import com.lowbudgetlcs.domain.account.models.Account
+import com.lowbudgetlcs.domain.account.models.types.AccountId
+import com.lowbudgetlcs.domain.account.models.types.Puuid
+import com.lowbudgetlcs.domain.player.PlayerService
+import com.lowbudgetlcs.domain.player.models.Player
+import com.lowbudgetlcs.domain.player.models.toPlayerId
+import com.lowbudgetlcs.domain.player.models.toPlayerName
+import com.lowbudgetlcs.domain.player.models.types.PlayerId
+import com.lowbudgetlcs.repositories.DatabaseException
+import com.lowbudgetlcs.repositories.account.IAccountRepository
+import com.lowbudgetlcs.repositories.player.IPlayerRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+/** The account from the production report: created, unowned, and refused as "already owned". */
+private val FULL_METAL_PUUID = Puuid("wtATP4ScufpCsr8o7FaDd2wQu5u3dZjPWLiU-W0dJ41EVO_JuSrDDBV680ygdBARc7H7GARUTtJjeA")
+private val ACCOUNT_ID = AccountId(1)
+private val OWNER = 3.toPlayerId()
+private val SOMEONE_ELSE = 2.toPlayerId()
+
+class PlayerAccountLinkTest :
+    StringSpec({
+        val playerRepo = mockk<IPlayerRepository>()
+        val accountRepo = mockk<IAccountRepository>()
+        val teamRepo = mockk<ITeamRepository>()
+        val service = PlayerService(playerRepo, accountRepo, teamRepo)
+
+        // Scoped to this spec's own mocks: clearAllMocks() is global and wipes the stubs of
+        // whatever spec is running concurrently.
+        beforeEach { clearMocks(playerRepo, accountRepo, teamRepo) }
+
+        val fullMetal = Player(OWNER, "Full Metal".toPlayerName())
+
+        /** An account held by [owner], or unowned when null. */
+        fun accountOwnedBy(owner: PlayerId?) = Account(ACCOUNT_ID, FULL_METAL_PUUID, owner)
+
+        "an unowned account links to the player" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns accountOwnedBy(null)
+            every { accountRepo.updatePlayerId(ACCOUNT_ID, OWNER) } returns accountOwnedBy(OWNER)
+
+            service.linkAccountToPlayer(OWNER, ACCOUNT_ID) shouldBe fullMetal
+
+            verify(exactly = 1) { accountRepo.updatePlayerId(ACCOUNT_ID, OWNER) }
+        }
+
+        "an account owned by another player is a conflict" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns accountOwnedBy(SOMEONE_ELSE)
+
+            val ex = shouldThrow<IllegalStateException> { service.linkAccountToPlayer(OWNER, ACCOUNT_ID) }
+
+            ex.message.toString() shouldContain "already owned"
+        }
+
+        "an account owned by another player is not quietly reassigned" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns accountOwnedBy(SOMEONE_ELSE)
+
+            shouldThrow<IllegalStateException> { service.linkAccountToPlayer(OWNER, ACCOUNT_ID) }
+
+            verify(exactly = 0) { accountRepo.updatePlayerId(any(), any()) }
+        }
+
+        "re-linking an account to the player who already owns it succeeds" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns accountOwnedBy(OWNER)
+            every { accountRepo.updatePlayerId(ACCOUNT_ID, OWNER) } returns accountOwnedBy(OWNER)
+
+            service.linkAccountToPlayer(OWNER, ACCOUNT_ID) shouldBe fullMetal
+        }
+
+        "an unknown account is not found" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns null
+
+            shouldThrow<NoSuchElementException> { service.linkAccountToPlayer(OWNER, ACCOUNT_ID) }
+        }
+
+        "an unknown player is not found, and the account is never read" {
+            every { playerRepo.getById(OWNER) } returns null
+
+            shouldThrow<NoSuchElementException> { service.linkAccountToPlayer(OWNER, ACCOUNT_ID) }
+
+            verify(exactly = 0) { accountRepo.getById(any()) }
+        }
+
+        "a failed write surfaces as a database error rather than a silent success" {
+            every { playerRepo.getById(OWNER) } returns fullMetal
+            every { accountRepo.getById(ACCOUNT_ID) } returns accountOwnedBy(null)
+            every { accountRepo.updatePlayerId(ACCOUNT_ID, OWNER) } returns null
+
+            shouldThrow<DatabaseException> { service.linkAccountToPlayer(OWNER, ACCOUNT_ID) }
+        }
+    })


### PR DESCRIPTION
Closes #235. Targets `main` — **merging this deploys production.**

`POST /api/v1/player/{playerId}/accounts` answered `409 Account already owned.` for accounts with no
owner at all, so a newly created Riot account could never be linked to a player.

The guard was inverted:

```kotlin
checkNotNull(account.playerId) { "Account already owned." }
```

`checkNotNull` throws when its argument **is** null, so it fired on exactly the accounts that were
free to claim and stayed silent on the ones already taken.

## Both directions were broken

| Account state | Spec says | Before | After |
|---|---|---|---|
| unowned | link it, 200 | **409** | 200 |
| owned by another player | 409 | **passes, then silently reassigned** | 409, no write |
| owned by this player | not a conflict | passes, rewrites same value | 200, idempotent |

The middle row is the half that was not reported: an account belonging to another player passed the
check and was quietly reassigned by the following `updatePlayerId`, returning 200. Any authenticated
caller could move an account off its owner. Authenticated-only on an admin-facing API, so not an
urgent exposure, but it shared the one-line cause.

The new guard allows null or the current owner and refuses anyone else, naming the holder:

```kotlin
val owner = account.playerId
check(owner == null || owner == playerId) { "Account already owned by player ${owner?.value}." }
```

Allowing the current owner follows the spec's own wording — 409 is documented for "another
player" — and makes a retried link a no-op instead of a spurious conflict.

**No spec change needed.** `documentation.yaml:1470` already says
`409: Riot account already assigned to another player`; only the code disagreed.
`unlinkAccountFromPlayer` already had the right shape.

## Why it shipped, and what stops it returning

`linkAccountToPlayer` had **no tests at all**, so nothing ever asserted which way the guard pointed —
the same underlying gap as #232.

`PlayerAccountLinkTest` is new and covers both directions plus the not-found and failed-write paths.
The load-bearing assertion is `verify(exactly = 0) { accountRepo.updatePlayerId(any(), any()) }` on
the conflict path: a 409 alone would not prove the reassignment is gone, since the old code produced
no 409 there at all.

It lives in its own file rather than in `PlayerServiceTest.kt` because that file still calls the
global `clearAllMocks()`, which races concurrently-running specs; this one resets only its own mocks.

**Verified red first.** Against unmodified `main`, four of the seven fail, and the failures are the
bug rather than a restatement of it:

- unowned account → `IllegalStateException: Account already owned.` — the production 409, reproduced
- owned by another player → no conflict raised at all; execution reached the unstubbed
  `updatePlayerId`, which is direct evidence of the silent reassignment

`checkNotNull` at `:78` was the only `checkNotNull` in the whole main source set — every other
ownership guard uses `check(!…)` correctly, so there is no wider pattern to sweep.

## Verification

- `./gradlew test --rerun-tasks` green; `PlayerAccountLinkTest` 7/7. `detekt` clean.
- Both changed files are ktlint-clean. `ktlintCheck` does fail on this branch, but every violation
  pre-exists in code this PR does not touch — in `PlayerService.kt` they are all on line 65, the
  `renamePlayer` line. Worth a separate cleanup pass.
- No version bump: production runs `:latest` and does not read the Gradle version.

**After merge**, the sequence that failed: `POST /api/v1/player/3/accounts` with account 1 must
return 200, confirmed linked via `GET /api/v1/player/3`. Then the other half — link an account
already held by a different player, expect 409, and confirm via `GET /api/v1/account` that its
`playerId` did **not** change.
