### PR TITLE
fix: Return a player's linked accounts instead of an empty list

### DIFF
--- a/src/itest/kotlin/account/AccountAndPlayerRepositoryTest.kt
+++ b/src/itest/kotlin/account/AccountAndPlayerRepositoryTest.kt
@@ -14,6 +14,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.testcontainers.JdbcDatabaseContainerSpecExtension
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -91,5 +94,23 @@ class AccountAndPlayerRepositoryTest :
             shouldThrow<IntegrityConstraintViolationException> {
                 accountRepo.insert(NewAccount(puuid, id))
             }
+        }
+
+        // Runs on the state the cases above leave behind: account (…794) belongs to player, and
+        // (…791) to player2.
+        "getByPlayerId returns only that player's accounts." {
+            val forPlayer = accountRepo.getByPlayerId(player.id)
+
+            forPlayer.shouldHaveSize(1)
+            forPlayer.single().id shouldBe account.id
+            forPlayer.single().playerId shouldBe player.id
+        }
+
+        "getByPlayerId does not return another player's accounts." {
+            accountRepo.getByPlayerId(player2.id).map { it.id } shouldNotContain account.id
+        }
+
+        "getByPlayerId returns empty for a player with no accounts." {
+            accountRepo.getByPlayerId((-1).toPlayerId()).shouldBeEmpty()
         }
     })

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/players/PlayerDtoMappers.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/players/PlayerDtoMappers.kt
@@ -1,8 +1,10 @@
 package com.lowbudgetlcs.api.dto.players
 
+import com.lowbudgetlcs.api.dto.accounts.toDto
 import com.lowbudgetlcs.api.dto.teams.toDto
 import com.lowbudgetlcs.domain.player.models.NewPlayer
 import com.lowbudgetlcs.domain.player.models.Player
+import com.lowbudgetlcs.domain.player.models.PlayerWithAccounts
 import com.lowbudgetlcs.domain.player.models.PlayerWithTeams
 import com.lowbudgetlcs.domain.player.models.types.PlayerName
 
@@ -10,12 +12,23 @@ fun NewPlayerDto.toNewPlayer(): NewPlayer = NewPlayer(
     name = PlayerName(name),
 )
 
-// TODO: Remove accounts from API contracts, or add PlayerWithAccounts back.
+// Reports no accounts because it has no way to know them. Correct for a freshly created player, but
+// it is also how players embedded in team responses are rendered, where accounts are silently
+// dropped — see the follow-up issue referenced in the PR.
 fun Player.toDto(): PlayerDto = PlayerDto(
     id = id.value,
     name = name.value,
     accounts = listOf(),
 )
 
+fun PlayerWithAccounts.toDto(): PlayerDto = PlayerDto(
+    id = id.value,
+    name = name.value,
+    accounts = accounts.map { it.toDto() },
+)
+
 fun PlayerWithTeams.toDto(): PlayerWithTeamsDto = PlayerWithTeamsDto(
-    id = id.value, name = name.value, accounts = listOf(), teams = teams.map { it.toDto() })
+    id = id.value,
+    name = name.value,
+    accounts = accounts.map { it.toDto() },
+    teams = teams.map { it.toDto() })

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/player/PlayerRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/player/PlayerRoutes.kt
@@ -27,7 +27,7 @@ private val logger: Logger = LoggerFactory.getLogger(Application::class.java)
 fun Route.playerRoutesV1(playerService: IPlayerService) {
     route("/player") {
         get<PlayerResources> {
-            val players = playerService.getAllPlayers()
+            val players = playerService.getAllPlayersWithAccounts()
             call.respond(players.map { it.toDto() })
         }
 
@@ -38,7 +38,7 @@ fun Route.playerRoutesV1(playerService: IPlayerService) {
             call.respond(HttpStatusCode.Created, created.toDto())
         }
         get<PlayerResources.ById> { route ->
-            val player = playerService.getPlayer(route.playerId.toPlayerId())
+            val player = playerService.getPlayerWithAccounts(route.playerId.toPlayerId())
             call.respond(player.toDto())
         }
 
@@ -46,7 +46,7 @@ fun Route.playerRoutesV1(playerService: IPlayerService) {
             val dto = call.receive<PatchPlayerDto>()
             logger.debug(dto.toString())
             val updated = playerService.renamePlayer(route.playerId.toPlayerId(), dto.name.toPlayerName())
-            call.respond(updated.toDto())
+            call.respond(playerService.getPlayerWithAccounts(updated.id).toDto())
         }
 
         get<PlayerResources.ByIdTeams> { route ->
@@ -62,7 +62,7 @@ fun Route.playerRoutesV1(playerService: IPlayerService) {
                     route.playerId.toPlayerId(),
                     dto.accountId.toAccountId(),
                 )
-            call.respond(updated.toDto())
+            call.respond(playerService.getPlayerWithAccounts(updated.id).toDto())
         }
 
         delete<PlayerResources.AccountById> { route ->
@@ -71,7 +71,7 @@ fun Route.playerRoutesV1(playerService: IPlayerService) {
                     route.playerId.toPlayerId(),
                     route.accountId.toAccountId(),
                 )
-            call.respond(updated.toDto())
+            call.respond(playerService.getPlayerWithAccounts(updated.id).toDto())
         }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/IPlayerService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/IPlayerService.kt
@@ -3,6 +3,7 @@ package com.lowbudgetlcs.domain.player
 import com.lowbudgetlcs.domain.account.models.types.AccountId
 import com.lowbudgetlcs.domain.player.models.NewPlayer
 import com.lowbudgetlcs.domain.player.models.Player
+import com.lowbudgetlcs.domain.player.models.PlayerWithAccounts
 import com.lowbudgetlcs.domain.player.models.PlayerWithTeams
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.player.models.types.PlayerName
@@ -11,6 +12,12 @@ interface IPlayerService {
     fun getAllPlayers(): List<Player>
 
     fun getPlayer(id: PlayerId): Player
+
+    /** Every player with their linked accounts attached. */
+    fun getAllPlayersWithAccounts(): List<PlayerWithAccounts>
+
+    /** A single player with their linked accounts attached. */
+    fun getPlayerWithAccounts(id: PlayerId): PlayerWithAccounts
 
     fun getPlayerWithTeams(id: PlayerId): PlayerWithTeams
 

--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/PlayerService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/PlayerService.kt
@@ -3,7 +3,9 @@ package com.lowbudgetlcs.domain.player
 import com.lowbudgetlcs.domain.account.models.types.AccountId
 import com.lowbudgetlcs.domain.player.models.NewPlayer
 import com.lowbudgetlcs.domain.player.models.Player
+import com.lowbudgetlcs.domain.player.models.PlayerWithAccounts
 import com.lowbudgetlcs.domain.player.models.PlayerWithTeams
+import com.lowbudgetlcs.domain.player.models.toPlayerWithAccounts
 import com.lowbudgetlcs.domain.player.models.toPlayerWithTeams
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.player.models.types.PlayerName
@@ -36,13 +38,32 @@ class PlayerService(
         return player
     }
 
+    override fun getAllPlayersWithAccounts(): List<PlayerWithAccounts> {
+        logger.info("Fetching all players with accounts...")
+        val players = playerRepository.getAll()
+        // One query for every account rather than one per player: this endpoint is unpaginated, so
+        // a per-player lookup would grow with the roster.
+        val accountsByPlayer = accountRepository.getAll().groupBy { it.playerId }
+        logger.debug("Fetched ${players.size} players.")
+        return players.map { it.toPlayerWithAccounts(accountsByPlayer[it.id].orEmpty()) }
+    }
+
+    override fun getPlayerWithAccounts(id: PlayerId): PlayerWithAccounts {
+        logger.info("Fetching player '$id' with accounts...")
+        val player = getPlayer(id)
+        val accounts = accountRepository.getByPlayerId(player.id)
+        logger.debug("Fetched ${accounts.size} accounts.")
+        return player.toPlayerWithAccounts(accounts)
+    }
+
     override fun getPlayerWithTeams(id: PlayerId): PlayerWithTeams {
         logger.info("Fetching player '$id' with teams...")
         val player = getPlayer(id)
         val teams = teamRepository.getByPlayerId(player.id)
-        logger.debug("Fetched ${teams.size} teams.")
+        val accounts = accountRepository.getByPlayerId(player.id)
+        logger.debug("Fetched ${teams.size} teams and ${accounts.size} accounts.")
         logger.debug(teams.toString())
-        return player.toPlayerWithTeams(player, teams)
+        return player.toPlayerWithTeams(accounts, teams)
     }
 
     override fun createPlayer(player: NewPlayer): Player {

--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/models/Extensions.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/models/Extensions.kt
@@ -1,5 +1,6 @@
 package com.lowbudgetlcs.domain.player.models
 
+import com.lowbudgetlcs.domain.account.models.Account
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.player.models.types.PlayerName
 import com.lowbudgetlcs.domain.team.models.Team
@@ -16,8 +17,15 @@ fun NewPlayer.toPlayer(id: PlayerId): Player =
         name = name,
     )
 
-fun Player.toPlayerWithTeams(player: Player, teams: List<Team>): PlayerWithTeams = PlayerWithTeams(
+fun Player.toPlayerWithTeams(accounts: List<Account>, teams: List<Team>): PlayerWithTeams = PlayerWithTeams(
     id = id,
     name = name,
+    accounts = accounts,
     teams = teams
+)
+
+fun Player.toPlayerWithAccounts(accounts: List<Account>): PlayerWithAccounts = PlayerWithAccounts(
+    id = id,
+    name = name,
+    accounts = accounts
 )

--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/models/PlayerWithAccounts.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/models/PlayerWithAccounts.kt
@@ -1,0 +1,11 @@
+package com.lowbudgetlcs.domain.player.models
+
+import com.lowbudgetlcs.domain.account.models.Account
+import com.lowbudgetlcs.domain.player.models.types.PlayerId
+import com.lowbudgetlcs.domain.player.models.types.PlayerName
+
+data class PlayerWithAccounts(
+    val id: PlayerId,
+    val name: PlayerName,
+    val accounts: List<Account>,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/domain/player/models/PlayerWithTeams.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/player/models/PlayerWithTeams.kt
@@ -1,5 +1,6 @@
 package com.lowbudgetlcs.domain.player.models
 
+import com.lowbudgetlcs.domain.account.models.Account
 import com.lowbudgetlcs.domain.player.models.types.PlayerId
 import com.lowbudgetlcs.domain.player.models.types.PlayerName
 import com.lowbudgetlcs.domain.team.models.Team
@@ -7,5 +8,6 @@ import com.lowbudgetlcs.domain.team.models.Team
 data class PlayerWithTeams(
     val id: PlayerId,
     val name: PlayerName,
+    val accounts: List<Account>,
     val teams: List<Team>,
 )

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/account/AccountRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/account/AccountRepository.kt
@@ -21,6 +21,12 @@ class AccountRepository(
     override fun getAccountByPuuid(puuid: Puuid): Account? =
         selectAccounts().where(RIOT_ACCOUNTS.RIOT_PUUID.eq(puuid.value)).fetchOne()?.let(::rowToAccount)
 
+    override fun getByPlayerId(playerId: PlayerId): List<Account> =
+        selectAccounts()
+            .where(RIOT_ACCOUNTS.PLAYER_ID.eq(playerId.value))
+            .fetch()
+            .mapNotNull(::rowToAccount)
+
     override fun insert(newAccount: NewAccount): Account? {
         val insertedId =
             dsl

--- a/src/main/kotlin/com/lowbudgetlcs/repositories/account/IAccountRepository.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/repositories/account/IAccountRepository.kt
@@ -13,6 +13,9 @@ interface IAccountRepository {
 
     fun getAccountByPuuid(puuid: Puuid): Account?
 
+    /** Every account linked to [playerId], empty when the player has none. */
+    fun getByPlayerId(playerId: PlayerId): List<Account>
+
     fun insert(newAccount: NewAccount): Account?
 
     fun updatePlayerId(

--- a/src/test/kotlin/services/PlayerWithAccountsTest.kt
+++ b/src/test/kotlin/services/PlayerWithAccountsTest.kt
@@ -1,0 +1,134 @@
+package services
+
+import com.lowbudgetlcs.api.dto.players.toDto
+import com.lowbudgetlcs.domain.account.models.Account
+import com.lowbudgetlcs.domain.account.models.types.AccountId
+import com.lowbudgetlcs.domain.account.models.types.Puuid
+import com.lowbudgetlcs.domain.player.PlayerService
+import com.lowbudgetlcs.domain.player.models.Player
+import com.lowbudgetlcs.domain.player.models.toPlayerId
+import com.lowbudgetlcs.domain.player.models.toPlayerName
+import com.lowbudgetlcs.domain.player.models.types.PlayerId
+import com.lowbudgetlcs.repositories.account.IAccountRepository
+import com.lowbudgetlcs.repositories.player.IPlayerRepository
+import com.lowbudgetlcs.repositories.team.ITeamRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+private val FULL_METAL = 3.toPlayerId()
+private val SEIR = 2.toPlayerId()
+
+/** Distinct 78-character base64url PUUIDs; only the last character differs. */
+private fun puuidOf(suffix: Char) =
+    Puuid("mCLCPW2XhEy2NpOk3yoDHWPN-Fu-tWnZ-klQ1lBMNgH38k-0JTN27aBh0xT9_F2aD4SvkLj1CpC79$suffix")
+
+private fun accountOf(
+    id: Int,
+    owner: PlayerId?,
+    suffix: Char,
+) = Account(AccountId(id), puuidOf(suffix), owner)
+
+class PlayerWithAccountsTest :
+    StringSpec({
+        val playerRepo = mockk<IPlayerRepository>()
+        val accountRepo = mockk<IAccountRepository>()
+        val teamRepo = mockk<ITeamRepository>()
+        val service = PlayerService(playerRepo, accountRepo, teamRepo)
+
+        beforeEach { clearMocks(playerRepo, accountRepo, teamRepo) }
+
+        val fullMetal = Player(FULL_METAL, "Full Metal".toPlayerName())
+        val seir = Player(SEIR, "seir".toPlayerName())
+
+        "a player's linked accounts come back on the player" {
+            val linked = listOf(accountOf(1, FULL_METAL, '1'), accountOf(2, FULL_METAL, '2'))
+            every { playerRepo.getById(FULL_METAL) } returns fullMetal
+            every { accountRepo.getByPlayerId(FULL_METAL) } returns linked
+
+            service.getPlayerWithAccounts(FULL_METAL).accounts shouldContainExactly linked
+        }
+
+        "the account reaches the DTO the API actually returns" {
+            every { playerRepo.getById(FULL_METAL) } returns fullMetal
+            every { accountRepo.getByPlayerId(FULL_METAL) } returns listOf(accountOf(1, FULL_METAL, '1'))
+
+            val dto = service.getPlayerWithAccounts(FULL_METAL).toDto()
+
+            dto.accounts.map { it.id } shouldContainExactly listOf(1)
+            dto.accounts.single().riotPuuid shouldBe puuidOf('1').value
+            dto.accounts.single().playerId shouldBe FULL_METAL.value
+        }
+
+        "a player with no accounts reports an empty list rather than failing" {
+            every { playerRepo.getById(FULL_METAL) } returns fullMetal
+            every { accountRepo.getByPlayerId(FULL_METAL) } returns emptyList()
+
+            service.getPlayerWithAccounts(FULL_METAL).accounts.shouldBeEmpty()
+        }
+
+        "an unknown player is still not found" {
+            every { playerRepo.getById(FULL_METAL) } returns null
+
+            shouldThrow<NoSuchElementException> { service.getPlayerWithAccounts(FULL_METAL) }
+        }
+
+        "the list endpoint gives each player only their own accounts" {
+            every { playerRepo.getAll() } returns listOf(fullMetal, seir)
+            every { accountRepo.getAll() } returns
+                listOf(
+                    accountOf(1, FULL_METAL, '1'),
+                    accountOf(2, SEIR, '2'),
+                    accountOf(3, FULL_METAL, '4'),
+                )
+
+            val byName = service.getAllPlayersWithAccounts().associateBy { it.name.value }
+
+            byName.getValue("Full Metal").accounts.map { it.id.value } shouldContainExactly listOf(1, 3)
+            byName.getValue("seir").accounts.map { it.id.value } shouldContainExactly listOf(2)
+        }
+
+        "an unlinked account is attached to nobody" {
+            every { playerRepo.getAll() } returns listOf(fullMetal, seir)
+            every { accountRepo.getAll() } returns listOf(accountOf(9, null, '1'))
+
+            service.getAllPlayersWithAccounts().forEach { it.accounts.shouldBeEmpty() }
+        }
+
+        "a player with no accounts still appears in the list" {
+            every { playerRepo.getAll() } returns listOf(fullMetal, seir)
+            every { accountRepo.getAll() } returns listOf(accountOf(1, FULL_METAL, '1'))
+
+            val all = service.getAllPlayersWithAccounts()
+
+            all.map { it.id } shouldContainExactly listOf(FULL_METAL, SEIR)
+            all.single { it.id == SEIR }.accounts.shouldBeEmpty()
+        }
+
+        "accounts are fetched once for the whole list, not once per player" {
+            every { playerRepo.getAll() } returns listOf(fullMetal, seir)
+            every { accountRepo.getAll() } returns listOf(accountOf(1, FULL_METAL, '1'))
+
+            service.getAllPlayersWithAccounts()
+
+            verify(exactly = 1) { accountRepo.getAll() }
+            verify(exactly = 0) { accountRepo.getByPlayerId(any()) }
+        }
+
+        "the teams view carries accounts as well as teams" {
+            every { playerRepo.getById(FULL_METAL) } returns fullMetal
+            every { teamRepo.getByPlayerId(FULL_METAL) } returns emptyList()
+            every { accountRepo.getByPlayerId(FULL_METAL) } returns listOf(accountOf(1, FULL_METAL, '1'))
+
+            val withTeams = service.getPlayerWithTeams(FULL_METAL)
+
+            withTeams.accounts.map { it.id.value } shouldContainExactly listOf(1)
+            withTeams.toDto().accounts.map { it.id } shouldContainExactly listOf(1)
+        }
+    })


### PR DESCRIPTION
Closes #237. Follow-up tracked in #238. Targets `main` — **merging this deploys production.**

Linking an account worked but left no trace in the API: `PlayerDto` has always carried an `accounts`
field and the mappers filled it with `listOf()`, under a TODO offering to either drop the field or
populate it.

```kotlin
// TODO: Remove accounts from API contracts, or add PlayerWithAccounts back.
accounts = listOf(),
```

**The spec was right all along, so nothing documented changes here.** `PlayerDto` and
`PlayerWithTeamsDto` both declare `accounts: array<RiotAccountDto>`, and `AccountDto` (`id`,
`riotPuuid`, `playerId`) already matches that schema field for field. This is the implementation
catching up to its own contract, not a new one.

`PlayerWithAccounts` was never actually a class — `git log -S` finds only the TODO — so it is built
on the existing `PlayerWithTeams` pattern rather than restored.

## What changed

The one genuinely missing piece was a way to read a player's accounts: `IAccountRepository` had
`getAll`, `getById`, `getAccountByPuuid`, `insert`, `updatePlayerId` and nothing else. `getByPlayerId`
reuses the existing private `selectAccounts()` / `rowToAccount()` helpers, so no new query plumbing
appears.

| Route | Now returns |
|---|---|
| `GET /player` | accounts per player, **two queries total** |
| `GET /player/{id}` | accounts |
| `GET /player/{id}/teams` | accounts as well as teams |
| `POST /player/{id}/accounts` (link) | the resulting state — no follow-up GET needed |
| `DELETE /player/{id}/accounts/{accountId}` (unlink) | the resulting state |
| `PATCH /player/{id}` | accounts, so a rename does not look like it dropped them |
| `POST /player` | unchanged — `[]` is correct for a brand-new player |

`getPlayer`/`getAllPlayers` keep their signatures, since `linkAccountToPlayer`,
`unlinkAccountFromPlayer` and `renamePlayer` call them internally; the enriched methods are additions.

**`GET /player` deliberately avoids an N+1.** It fetches every account once and groups by `playerId`
in memory, so the endpoint stays at two queries regardless of roster size — it is unpaginated, so a
per-player lookup would grow with it. `verify(exactly = 1) { accountRepo.getAll() }` plus
`verify(exactly = 0) { getByPlayerId(any()) }` pin that, because the naive version would pass every
other assertion in this PR.

`toPlayerWithTeams` also lost its redundant second `Player` parameter — it took both a receiver and
the same value as an argument, so the only call site read
`player.toPlayerWithTeams(player, teams)`.

## Tests

New `PlayerWithAccountsTest` (9 cases). The ones doing real work beyond the happy path:

- **one player's accounts never appear on another** — the assertion that actually protects the
  `groupBy`, which a per-player implementation would also satisfy
- **an unlinked account (`playerId = null`) is attached to nobody**
- **a player with no accounts still appears** in the list, with an empty array rather than being
  dropped
- the account survives all the way into `PlayerDto`, asserted on `riotPuuid` and `playerId`, so this
  covers the mapper rather than only the service
- the `/teams` view carries both

Three new itest cases in `AccountAndPlayerRepositoryTest` for `getByPlayerId` — only that player's
rows, none of another player's, and empty for a player with none — against real Postgres via the
existing testcontainer.

`PlayerServiceTest` is untouched, deliberately: it still uses the global `clearAllMocks()`, so the
new spec resets only its own mocks rather than joining that race.

## Verification

- `./gradlew test --rerun-tasks` green (`PlayerWithAccountsTest` 9/9); `./gradlew itest` green
  (`AccountAndPlayerRepositoryTest` 7/7); `detekt` clean.
- **ktlint: zero new violations, measured rather than asserted.** `ktlintCheck` fails on this branch,
  as it does on `main`. Running it on `main` and on this branch gives **173 violations both times**,
  and the per-file lists for every file this PR touches are byte-identical. The pre-existing debt is
  worth a separate cleanup pass — `PlayerService.kt:65`, `PlayerDtoMappers.kt` and
  `player/models/Extensions.kt` all had violations before this change and still have exactly those.
- Spec unchanged; responses still satisfy it.

**After merge**, against prod: `GET /api/v1/player/3` should show account 1 under `accounts`, and
`GET /api/v1/player` should show it on player 3 only. Re-running the link call should return the
account in the response body itself. Unlinking should drop it from the player and leave it with
`playerId: null` on `GET /api/v1/account`.

## Known gap

Players embedded in team responses (`TeamWithPlayersDto.players`) still report no accounts, because
they map through `Player.toDto()`. That needs `TeamWithPlayers` to carry accounts and the team
service to fetch them without an N+1 — more surface than a production hotfix should take on, so it
is **#238** rather than a silent omission. The remaining TODO in `PlayerDtoMappers.kt` was reworded
to name that single case instead of describing work now done.
