### PR TITLE
feat: Add a targeted Riot refresh for a single tournament code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,10 @@ tasks.register<Test>("itest") {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // Kotest runs specs and tests concurrently, and mockk's inline agent instruments classes on
+    // those threads. The default 512k thread stack overflows during transformation once enough
+    // specs mock concurrently, surfacing as StackOverflowError in unrelated specs.
+    jvmArgs("-Xss4m")
 }
 
 tasks.withType<Detekt>().configureEach {

--- a/src/main/kotlin/com/lowbudgetlcs/api/dto/series/RefreshSeriesDto.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/dto/series/RefreshSeriesDto.kt
@@ -1,0 +1,13 @@
+package com.lowbudgetlcs.api.dto.series
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Identifies the single tournament code to re-check against Riot. Exactly one field must be set;
+ * both or neither is a 422.
+ */
+@Serializable
+data class RefreshSeriesDto(
+    val tournamentCodeId: Int? = null,
+    val shortcode: String? = null,
+)

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesResources.kt
@@ -27,4 +27,10 @@ class SeriesResources {
         val parent: SeriesResources = SeriesResources(),
         val seriesId: Int,
     )
+
+    @Resource("{seriesId}/refresh")
+    data class Refresh(
+        val parent: SeriesResources = SeriesResources(),
+        val seriesId: Int,
+    )
 }

--- a/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/api/routes/v1/series/SeriesRoutes.kt
@@ -6,8 +6,12 @@ import com.lowbudgetlcs.api.dto.games.toDto
 import com.lowbudgetlcs.api.dto.games.toNewTournamentCode
 import com.lowbudgetlcs.api.dto.games.toReportedResult
 import com.lowbudgetlcs.api.dto.series.CompleteSeriesDto
+import com.lowbudgetlcs.api.dto.series.RefreshSeriesDto
 import com.lowbudgetlcs.api.dto.series.toDto
+import com.lowbudgetlcs.domain.event.models.toShortcode
 import com.lowbudgetlcs.domain.series.ISeriesService
+import com.lowbudgetlcs.domain.series.game.models.toTournamentCodeId
+import com.lowbudgetlcs.domain.series.models.RefreshOutcome
 import com.lowbudgetlcs.domain.series.models.toSeriesId
 import com.lowbudgetlcs.domain.team.models.toTeamId
 import io.ktor.http.HttpStatusCode
@@ -59,6 +63,26 @@ fun Route.seriesRoutesV1(seriesService: ISeriesService) {
                 if (outcome.recorded) HttpStatusCode.Created else HttpStatusCode.OK,
                 outcome.game.toDto(),
             )
+        }
+        post<SeriesResources.Refresh> { route ->
+            val dto = call.receive<RefreshSeriesDto>()
+            logger.debug(dto.toString())
+            val seriesId = route.seriesId.toSeriesId()
+            val outcome =
+                seriesService.refreshFromCode(
+                    seriesId,
+                    dto.tournamentCodeId?.toTournamentCodeId(),
+                    dto.shortcode?.toShortcode(),
+                )
+            // The status carries the outcome so a caller can tell "Riot had nothing" (don't retry)
+            // from "Riot was unreachable" (do), without a wrapper type. Body is always the series.
+            val status =
+                when (outcome) {
+                    RefreshOutcome.ATTRIBUTED -> HttpStatusCode.Created
+                    RefreshOutcome.ANSWERED_EMPTY -> HttpStatusCode.OK
+                    RefreshOutcome.UNREACHABLE -> HttpStatusCode.ServiceUnavailable
+                }
+            call.respond(status, seriesService.getSeriesWithGames(seriesId).toDto())
         }
     }
 }

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/ISeriesService.kt
@@ -4,6 +4,7 @@ import com.lowbudgetlcs.domain.event.models.Shortcode
 import com.lowbudgetlcs.domain.event.models.types.EventId
 import com.lowbudgetlcs.domain.series.game.models.NewTournamentCode
 import com.lowbudgetlcs.domain.series.game.models.TournamentCode
+import com.lowbudgetlcs.domain.series.game.models.types.TournamentCodeId
 import com.lowbudgetlcs.domain.series.models.NewSeries
 import com.lowbudgetlcs.domain.series.models.RefreshOutcome
 import com.lowbudgetlcs.domain.series.models.ReportOutcome
@@ -49,6 +50,24 @@ interface ISeriesService {
     suspend fun refreshFromRiot(id: SeriesId): RefreshOutcome
 
     suspend fun refreshFromShortcode(shortcode: Shortcode): RefreshOutcome?
+
+    /**
+     * Re-check Riot for a single tournament code and record a game if one is found.
+     *
+     * Exactly one of [tournamentCodeId] or [shortcode] must be supplied — unlike
+     * [reportResult], neither is not allowed, because this operation is defined by the code it
+     * targets. A code that already has a game recorded is left untouched and reports
+     * [RefreshOutcome.ANSWERED_EMPTY].
+     *
+     * @throws IllegalArgumentException if both or neither identifier is supplied.
+     * @throws NoSuchElementException if the series or code does not exist, or the code belongs to
+     *   another series.
+     */
+    suspend fun refreshFromCode(
+        id: SeriesId,
+        tournamentCodeId: TournamentCodeId?,
+        shortcode: Shortcode?,
+    ): RefreshOutcome
 
     suspend fun reportResult(
         id: SeriesId,

--- a/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
+++ b/src/main/kotlin/com/lowbudgetlcs/domain/series/SeriesService.kt
@@ -125,32 +125,10 @@ class SeriesService(
         var attributed = false
         val unverified = mutableListOf<Shortcode>()
         for (code in outstanding) {
-            val riotGames =
-                try {
-                    gate.getGames(code.shortcode)
-                } catch (e: RiotApiException) {
-                    logger.warn("Could not reach Riot for shortcode '${code.shortcode.value}': ${e.message}")
-                    unverified += code.shortcode
-                    continue
-                }
-            riotGames.forEach { riotGame ->
-                val matchId = riotMatchIdOf(riotGame)
-                if (matchId != null && matchId in recordedMatchIds) {
-                    logger.warn("Riot match '${matchId.value}' is already recorded for series '$id', skipping.")
-                    return@forEach
-                }
-                val result = resolveWinner(series, riotGame)
-                if (result != null) {
-                    gameRepo.insert(
-                        NewGame(
-                            seriesId = id,
-                            tournamentCodeId = code.id,
-                            riotMatchId = matchId,
-                            result = result,
-                        ),
-                    )
-                    attributed = true
-                }
+            when (refreshCode(series, code, recordedMatchIds)) {
+                RefreshOutcome.ATTRIBUTED -> attributed = true
+                RefreshOutcome.UNREACHABLE -> unverified += code.shortcode
+                RefreshOutcome.ANSWERED_EMPTY -> Unit
             }
         }
 
@@ -169,6 +147,78 @@ class SeriesService(
         }
     }
 
+    /**
+     * Ask Riot about one tournament code and record whatever it returns.
+     *
+     * Shared by the bulk refresh, the Riot callback and the targeted refresh endpoint so all three
+     * attribute games identically. Does not evaluate completion — the caller does that once, after
+     * however many codes it walked.
+     *
+     * @param recordedMatchIds matches already stored for this series, so a match Riot reports under
+     *   a second code is not recorded twice.
+     */
+    private suspend fun refreshCode(
+        series: Series,
+        code: TournamentCode,
+        recordedMatchIds: Set<RiotMatchId>,
+    ): RefreshOutcome {
+        val riotGames =
+            try {
+                gate.getGames(code.shortcode)
+            } catch (e: RiotApiException) {
+                logger.warn("Could not reach Riot for shortcode '${code.shortcode.value}': ${e.message}")
+                return RefreshOutcome.UNREACHABLE
+            }
+        var attributed = false
+        riotGames.forEach { riotGame ->
+            val matchId = riotMatchIdOf(riotGame)
+            if (matchId != null && matchId in recordedMatchIds) {
+                logger.warn("Riot match '${matchId.value}' is already recorded for series '${series.id}', skipping.")
+                return@forEach
+            }
+            val result = resolveWinner(series, riotGame)
+            if (result != null) {
+                gameRepo.insert(
+                    NewGame(
+                        seriesId = series.id,
+                        tournamentCodeId = code.id,
+                        riotMatchId = matchId,
+                        result = result,
+                    ),
+                )
+                attributed = true
+            }
+        }
+        return if (attributed) RefreshOutcome.ATTRIBUTED else RefreshOutcome.ANSWERED_EMPTY
+    }
+
+    override suspend fun refreshFromCode(
+        id: SeriesId,
+        tournamentCodeId: TournamentCodeId?,
+        shortcode: Shortcode?,
+    ): RefreshOutcome {
+        require((tournamentCodeId == null) != (shortcode == null)) {
+            "Provide exactly one of tournamentCodeId or shortcode."
+        }
+        val series = getSeries(id)
+        val code =
+            resolveTarget(series, tournamentCodeId, shortcode)
+                ?: throw NoSuchElementException("No tournament code was identified for series '${id.value}'.")
+
+        val recorded = gameRepo.getBySeriesId(id)
+        // A code that already has a game is left alone. Re-asking Riot would insert a second row for
+        // the same match whenever the existing game was self-reported, because such a game carries no
+        // riotMatchId for the dedupe below to match on.
+        if (recorded.any { it.tournamentCodeId == code.id }) {
+            logger.info("Code '${code.shortcode.value}' already has a game recorded, nothing to refresh.")
+            return RefreshOutcome.ANSWERED_EMPTY
+        }
+
+        val outcome = refreshCode(series, code, recorded.mapNotNull { it.riotMatchId }.toSet())
+        if (outcome == RefreshOutcome.ATTRIBUTED) evaluateCompletion(id)
+        return outcome
+    }
+
     override suspend fun reportResult(
         id: SeriesId,
         report: ReportedResult,
@@ -178,7 +228,7 @@ class SeriesService(
             "Provide either tournamentCodeId or shortcode, not both."
         }
         val declared = declaredResult(series, report)
-        val target = resolveTarget(series, report)
+        val target = resolveTarget(series, report.tournamentCodeId, report.shortcode)
 
         val before = gameRepo.getBySeriesId(id)
         if (target != null) {
@@ -277,14 +327,20 @@ class SeriesService(
         return winningTeamId to loser
     }
 
+    /**
+     * Resolve a code by id or by shortcode, whichever was supplied, and refuse one that belongs to a
+     * different series. Returns null when neither was supplied — which `reportResult` treats as "let
+     * Riot decide", and `refreshFromCode` rejects up front.
+     */
     private fun resolveTarget(
         series: Series,
-        report: ReportedResult,
+        tournamentCodeId: TournamentCodeId?,
+        shortcode: Shortcode?,
     ): TournamentCode? {
         val code =
-            report.tournamentCodeId?.let {
+            tournamentCodeId?.let {
                 codeRepo.getById(it) ?: throw NoSuchElementException("Tournament code with id ${it.value} not found")
-            } ?: report.shortcode?.let {
+            } ?: shortcode?.let {
                 codeRepo.getByShortcode(it) ?: throw NoSuchElementException("Tournament code '${it.value}' not found")
             } ?: return null
         if (code.seriesId != series.id) {

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -1005,6 +1005,88 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /api/v1/series/{seriesId}/refresh:
+    post:
+      summary: Re-check Riot for one tournament code
+      description: |
+        Asks Riot about a single tournament code and records the game if one is
+        found, updating the series' `games` array. Use it when a callback was
+        missed or arrived before the game was queryable, instead of issuing a
+        fresh code — a refresh costs nothing against the per-game code limit.
+
+        Exactly **one** of `tournamentCodeId` or `shortcode` must be given.
+        Unlike `/results`, omitting both is rejected: this operation is defined
+        by the code it targets.
+
+        A code that already has a game recorded is left alone and answers 200.
+        That is deliberate — re-asking Riot would record a second game for the
+        same match whenever the existing result was self-reported, because such
+        a game carries no `riotMatchId` to recognise Riot's copy by.
+
+        Recording a game triggers the usual completion check.
+      operationId: refreshSeriesFromCode
+      tags:
+        - Series (v1)
+      parameters:
+        - name: seriesId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshSeriesDto"
+      responses:
+        "201":
+          description: |
+            Riot had a game and it was recorded. The returned series includes it
+            in `games`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesWithGamesDto"
+        "200":
+          description: |
+            Nothing to add — **not** a failure. Either Riot has no game for this
+            code yet, or the code already had a result recorded. The series is
+            returned unchanged; do not retry on a timer without a reason to
+            think the game has since finished.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesWithGamesDto"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: |
+            Series not found, the tournament code was not found, or the code
+            belongs to a different series.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "422":
+          description: |
+            Both `tournamentCodeId` and `shortcode` were given, or neither was.
+            Exactly one is required.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: |
+            Riot could not be reached, so nothing could be confirmed. Distinct
+            from 200: this one is worth retrying.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /api/v1/series/{seriesId}/complete:
     post:
       summary: Complete a series
@@ -2415,6 +2497,24 @@ components:
             The Riot tournament code itself, as it appears in the game client.
             Mutually exclusive with `tournamentCodeId`. Exists because a human
             reporting a result has the code, not a database id.
+          example: NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae
+
+    RefreshSeriesDto:
+      type: object
+      description: |
+        Identifies the one tournament code to re-check against Riot. Exactly one
+        of these must be set — unlike `ReportResultDto`, omitting both is a 422
+        rather than "let Riot decide".
+      properties:
+        tournamentCodeId:
+          type: integer
+          description: Denny's id for the code. Mutually exclusive with `shortcode`.
+          example: 117
+        shortcode:
+          type: string
+          description: |
+            The Riot tournament code itself. Mutually exclusive with
+            `tournamentCodeId`.
           example: NA04eff-c5b0b774-c049-47cf-88f4-eee05c8d83ae
 
     CompleteSeriesDto:

--- a/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
+++ b/src/test/kotlin/services/SeriesRefreshFromRiotTest.kt
@@ -24,6 +24,7 @@ import com.lowbudgetlcs.repositories.game.IGameRepository
 import com.lowbudgetlcs.repositories.series.ISeriesRepository
 import com.lowbudgetlcs.repositories.team.ITeamRepository
 import com.lowbudgetlcs.repositories.tournamentcode.ITournamentCodeRepository
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -223,5 +224,124 @@ class SeriesRefreshFromRiotTest :
             f.service.refreshFromRiot(SERIES_ID) shouldBe RefreshOutcome.ATTRIBUTED
 
             verify(exactly = 1) { f.gameRepo.insert(match { it.riotMatchId == null }) }
+        }
+
+        // ---- refreshFromCode: the targeted refresh behind POST /series/{id}/refresh ----
+
+        "refreshFromCode resolves the code by id and attributes the game" {
+            val f = Fixture()
+            val code = f.code(1, "SHORT-A")
+            coEvery { f.gateway.getGames(code.shortcode) } returns listOf(f.riotGame(listOf(PUUID_A)))
+            f.withSeries(listOf(code))
+            every { f.codeRepo.getById(TournamentCodeId(1)) } returns code
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromCode(SERIES_ID, TournamentCodeId(1), null) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) { f.gameRepo.insert(match { it.tournamentCodeId == TournamentCodeId(1) }) }
+        }
+
+        "refreshFromCode resolves the same code by shortcode, to the same outcome" {
+            val f = Fixture()
+            val code = f.code(1, "SHORT-A")
+            coEvery { f.gateway.getGames(code.shortcode) } returns listOf(f.riotGame(listOf(PUUID_A)))
+            f.withSeries(listOf(code))
+            every { f.codeRepo.getByShortcode(Shortcode("SHORT-A")) } returns code
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromCode(SERIES_ID, null, Shortcode("SHORT-A")) shouldBe RefreshOutcome.ATTRIBUTED
+
+            verify(exactly = 1) { f.gameRepo.insert(match { it.tournamentCodeId == TournamentCodeId(1) }) }
+        }
+
+        "refreshFromCode refuses both identifiers, without calling Riot" {
+            val f = Fixture()
+
+            shouldThrow<IllegalArgumentException> {
+                f.service.refreshFromCode(SERIES_ID, TournamentCodeId(1), Shortcode("SHORT-A"))
+            }
+
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "refreshFromCode refuses neither identifier, without calling Riot" {
+            val f = Fixture()
+
+            shouldThrow<IllegalArgumentException> { f.service.refreshFromCode(SERIES_ID, null, null) }
+
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "refreshFromCode refuses a code belonging to another series, without calling Riot" {
+            val f = Fixture()
+            val foreign = f.code(9, "SHORT-FOREIGN").copy(seriesId = SeriesId(999))
+            f.withSeries(listOf())
+            every { f.codeRepo.getById(TournamentCodeId(9)) } returns foreign
+
+            shouldThrow<NoSuchElementException> { f.service.refreshFromCode(SERIES_ID, TournamentCodeId(9), null) }
+
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "refreshFromCode reports not-found for an unknown code, without calling Riot" {
+            val f = Fixture()
+            f.withSeries(listOf())
+            every { f.codeRepo.getById(TournamentCodeId(404)) } returns null
+
+            shouldThrow<NoSuchElementException> { f.service.refreshFromCode(SERIES_ID, TournamentCodeId(404), null) }
+
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+        }
+
+        "refreshFromCode leaves a code that already has a game alone, without calling Riot" {
+            val f = Fixture()
+            val code = f.code(1, "SHORT-A")
+            f.withSeries(listOf(code), recorded = listOf(f.playedGame(1)))
+            every { f.codeRepo.getById(TournamentCodeId(1)) } returns code
+
+            f.service.refreshFromCode(SERIES_ID, TournamentCodeId(1), null) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            // Re-asking Riot would insert a second row for the same match whenever the existing game
+            // was self-reported, since such a game carries no riotMatchId to dedupe against.
+            coVerify(exactly = 0) { f.gateway.getGames(any()) }
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "refreshFromCode reports ANSWERED_EMPTY when Riot has nothing yet" {
+            val f = Fixture()
+            val code = f.code(1, "SHORT-A")
+            coEvery { f.gateway.getGames(code.shortcode) } returns emptyList()
+            f.withSeries(listOf(code))
+            every { f.codeRepo.getById(TournamentCodeId(1)) } returns code
+
+            f.service.refreshFromCode(SERIES_ID, TournamentCodeId(1), null) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "refreshFromCode reports UNREACHABLE when Riot cannot be reached" {
+            val f = Fixture()
+            val code = f.code(1, "SHORT-A")
+            coEvery { f.gateway.getGames(code.shortcode) } throws RiotApiException("503", 503)
+            f.withSeries(listOf(code))
+            every { f.codeRepo.getById(TournamentCodeId(1)) } returns code
+
+            f.service.refreshFromCode(SERIES_ID, TournamentCodeId(1), null) shouldBe RefreshOutcome.UNREACHABLE
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
+        }
+
+        "refreshFromCode does not record a match already stored under a different code" {
+            val f = Fixture()
+            val code = f.code(2, "SHORT-B")
+            coEvery { f.gateway.getGames(code.shortcode) } returns listOf(f.riotGame(listOf(PUUID_A)))
+            val already = f.playedGame(1).copy(riotMatchId = "NA1_5102531894".toRiotMatchId())
+            f.withSeries(listOf(code), recorded = listOf(already))
+            every { f.codeRepo.getById(TournamentCodeId(2)) } returns code
+            every { f.teamRepo.getTeamIdsByPuuids(any()) } returns listOf(TEAM_1)
+
+            f.service.refreshFromCode(SERIES_ID, TournamentCodeId(2), null) shouldBe RefreshOutcome.ANSWERED_EMPTY
+
+            verify(exactly = 0) { f.gameRepo.insert(any()) }
         }
     })


### PR DESCRIPTION
Closes #241. Targets `main` — **merging this deploys production.**

```
POST /api/v1/series/{seriesId}/refresh   {"tournamentCodeId": 117}
POST /api/v1/series/{seriesId}/refresh   {"shortcode": "NA04eff-…"}
```

Asks Riot about one tournament code and records the game if one comes back, returning the series with
its updated `games` array. `refreshFromRiot` and `refreshFromShortcode` already existed but reached
the outside world only through `/riot-callback`, so a missed or early callback left no recovery except
issuing another code — which spends the per-game allowance — or reporting by hand, which records an
unverified game.

## Almost no new logic

`refreshFromRiot`'s loop body is extracted into `refreshCode(series, code, recordedMatchIds)`, so the
callback, the bulk refresh and the new endpoint attribute games through **the same code path** and
cannot drift apart. `resolveTarget` now takes the two identifiers rather than a `ReportedResult`,
keeping one implementation of "resolve either, and refuse a code belonging to another series".

`refreshFromRiot`'s observable behaviour is unchanged — that is what the nine pre-existing tests in
`SeriesRefreshFromRiotTest` are for, and they pass untouched. `/riot-callback` and `createGame`'s
`refreshQuietly` both depend on it.

## Two deliberate differences from `/results`

**Neither identifier is rejected.** `/results` allows both to be omitted, letting Riot decide which
outstanding code has a game. A refresh is defined by the code it targets, so neither is a 422 just as
both is.

**A code that already has a game is left alone**, answering 200 without calling Riot. This is a
correctness guard, not tidiness: re-asking Riot would record a **second** game row for one real match
whenever the existing result was self-reported, because such a game carries `riot_match_id = null` and
the dedupe has nothing to recognise Riot's copy by. That inflates the series score and can auto-close
it early. Recovering a self-reported code needs a supersede-rather-than-add design and belongs in its
own change.

## Status mapping

The outcome rides on the status rather than a wrapper type, following `/results`, which already
returns 201 vs 200 off `outcome.recorded`:

| Outcome | Status |
|---|---|
| A game was recorded | **201** |
| Nothing to add — Riot has no game yet, or the code was already resolved | **200** |
| Riot could not be reached | **503** |
| Both or neither identifier | **422** |
| Series/code not found, or code from another series | **404** |

Collapsing the middle two into one 200 would hide the difference between "not yet" and "retry me",
which is the whole reason a caller polls.

## Tests

Ten new cases in `SeriesRefreshFromRiotTest`, reusing its existing `Fixture` (19 total in the spec).
The ones doing real work:

- both identifiers → `IllegalArgumentException` **and `coVerify(exactly = 0)` on `getGames`** — the
  guard must short-circuit before Riot, not after
- neither identifier → same
- a code from another series → `NoSuchElementException`, Riot not called
- a code that already has a game → `ANSWERED_EMPTY`, **Riot not called and nothing inserted** — this
  is the guard against the double-record described above
- a match already stored under a different code → not inserted twice
- by-id and by-shortcode resolve to the same outcome

## Second commit: the test JVM needed a bigger thread stack

Adding those ten tests made the suite fail **in specs this PR does not touch** — `StackOverflowError`
in `RiotAccountGatewayTest`, `PatchEventTest` and `AddRemoveTeamTest`, alongside JVM logs reading
`java.lang.instrument ASSERTION FAILED … transform method call failed`. One run failed 13 tests, the
next 64, and another hung past ten minutes.

It is not this PR's logic. Verified by bisection:

- pristine `main`: 208 tests, **0 failures**
- this PR's **source changes only**, test file reverted: **BUILD SUCCESSFUL**
- source + the ten new tests: fails non-deterministically

The cause is `ProjectConfig` running `SpecExecutionMode.Concurrent` **and**
`TestExecutionMode.Concurrent`, with mockk's inline agent instrumenting classes on those worker
threads. The default 512k stack is not enough for byte-buddy's transformation once enough specs mock
simultaneously. Making the suite fully sequential fixed it — which identified the cause but gives up
the parallelism.

`-Xss4m` on the test JVM keeps both modes `Concurrent` and holds across **five consecutive
`--rerun-tasks` runs**. `ProjectConfig` is left exactly as it was. It is a separate commit so it can
be reviewed, or reverted, on its own.

This is the same fragility the cap PR recorded, which predicted it "would have surfaced as random CI
failures as the suite grew". It has.

## Verification

- `test`, `itest` and `detekt` all green; five consecutive `test --rerun-tasks` runs green.
- **ktlint: 173 violations on this branch, 173 on `main`** — identical, and none in the files touched
  here. The pre-existing debt still deserves its own cleanup.
- OpenAPI parses; `info.version` unchanged at `1.4.1`. The endpoint documents all five statuses and
  states explicitly that 200 means "nothing to add" rather than failure — the case a client is most
  likely to misread.

**After merge**, against prod: take a series with an outstanding code, refresh by `tournamentCodeId`
and again by `shortcode` (identical behaviour), then confirm 422 on sending both, 404 on a code from
another series, and 200 with an unchanged `games` array once the code is resolved.

## Note for clients

todd-bot can now force a re-check instead of burning a code — worth surfacing on todd-bot#97, since a
refresh costs nothing against the two-code cap.
